### PR TITLE
OCPEDGE-2408, OCPEDGE-2410: Add AdaptableTopology feature gate and enum to Infrastructure API

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AdaptableTopology.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AdaptableTopology.yaml
@@ -1,0 +1,81 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Infrastructure"
+crdName: infrastructures.config.openshift.io
+featureGates:
+- AdaptableTopology
+tests:
+  onCreate:
+    - name: Should be able to create a minimal Infrastructure
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {} # No spec is required for a Infrastructure
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+  onUpdate:
+    - name: status should allow controlPlaneTopology value for `Adaptable` on platform None
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+        status:
+          controlPlaneTopology: Adaptable
+          infrastructureTopology: HighlyAvailable
+          platform: None
+          platformStatus:
+            type: None
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+        status:
+          controlPlaneTopology: Adaptable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: None
+          platformStatus:
+            type: None
+    - name: status should allow infrastructureTopology value for `Adaptable` on platform None
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: Adaptable
+          platform: None
+          platformStatus:
+            type: None
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: Adaptable
+          platform: None
+          platformStatus:
+            type: None

--- a/config/v1/tests/infrastructures.config.openshift.io/DualReplica+AdaptableTopology.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/DualReplica+AdaptableTopology.yaml
@@ -1,0 +1,116 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Infrastructure"
+crdName: infrastructures.config.openshift.io
+featureGates:
+- DualReplica
+- AdaptableTopology
+tests:
+  onCreate:
+    - name: Should be able to create a minimal Infrastructure
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {} # No spec is required for a Infrastructure
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+  onUpdate:
+    - name: status should allow controlPlaneTopology value for `Adaptable`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+        status:
+          controlPlaneTopology: Adaptable
+          infrastructureTopology: HighlyAvailable
+          platform: None
+          platformStatus:
+            type: None
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: None
+        status:
+          controlPlaneTopology: Adaptable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: None
+          platformStatus:
+            type: None
+    - name: status should allow controlPlaneTopology value for `DualReplica`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: BareMetal
+            baremetal: {}
+        status:
+          controlPlaneTopology: DualReplica
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: OpenShiftManagedDefault
+            type: BareMetal
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: BareMetal
+            baremetal: {}
+        status:
+          controlPlaneTopology: DualReplica
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: OpenShiftManagedDefault
+            type: BareMetal
+    - name: should not allow changing infrastructureTopology value to `DualReplica`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: BareMetal
+            baremetal: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: DualReplica
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: OpenShiftManagedDefault
+            type: BareMetal
+      expectedStatusError: 'status.infrastructureTopology: Unsupported value: "DualReplica": supported values: "HighlyAvailable", "SingleReplica"'

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -107,6 +107,7 @@ type InfrastructureStatus struct {
 	// +kubebuilder:default=HighlyAvailable
 	// +openshift:validation:FeatureGateAwareEnum:featureGate="",enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;External
 	// +openshift:validation:FeatureGateAwareEnum:featureGate=DualReplica,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;External
+	// +openshift:validation:FeatureGateAwareEnum:featureGate=AdaptableTopology,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;Adaptable;External
 	// +optional
 	ControlPlaneTopology TopologyMode `json:"controlPlaneTopology"`
 
@@ -119,6 +120,7 @@ type InfrastructureStatus struct {
 	// NOTE: External topology mode is not applicable for this field.
 	// +kubebuilder:default=HighlyAvailable
 	// +kubebuilder:validation:Enum=HighlyAvailable;SingleReplica
+	// +openshift:validation:FeatureGateAwareEnum:featureGate=AdaptableTopology,enum=HighlyAvailable;SingleReplica;Adaptable
 	// +optional
 	InfrastructureTopology TopologyMode `json:"infrastructureTopology,omitempty"`
 
@@ -159,6 +161,10 @@ const (
 	// that any of the control plane components such as kubernetes API server or etcd are visible within
 	// the cluster.
 	ExternalTopologyMode TopologyMode = "External"
+
+	// "Adaptable" is for clusters that dynamically adjust control-plane and
+	// infrastructure behavior based on current node count.
+	AdaptableTopologyMode TopologyMode = "Adaptable"
 )
 
 // CPUPartitioningMode defines the mode for CPU partitioning

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -108,6 +108,7 @@ type InfrastructureStatus struct {
 	// +openshift:validation:FeatureGateAwareEnum:featureGate="",enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;External
 	// +openshift:validation:FeatureGateAwareEnum:featureGate=DualReplica,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;External
 	// +openshift:validation:FeatureGateAwareEnum:featureGate=AdaptableTopology,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;Adaptable;External
+	// +openshift:validation:FeatureGateAwareEnum:requiredFeatureGate=DualReplica;AdaptableTopology,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;Adaptable;External
 	// +optional
 	ControlPlaneTopology TopologyMode `json:"controlPlaneTopology"`
 
@@ -119,7 +120,7 @@ type InfrastructureStatus struct {
 	// and the operators should not configure the operand for highly-available operation
 	// NOTE: External topology mode is not applicable for this field.
 	// +kubebuilder:default=HighlyAvailable
-	// +kubebuilder:validation:Enum=HighlyAvailable;SingleReplica
+	// +openshift:validation:FeatureGateAwareEnum:featureGate="",enum=HighlyAvailable;SingleReplica
 	// +openshift:validation:FeatureGateAwareEnum:featureGate=AdaptableTopology,enum=HighlyAvailable;SingleReplica;Adaptable
 	// +optional
 	InfrastructureTopology TopologyMode `json:"infrastructureTopology,omitempty"`

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
@@ -3,11 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -223,6 +222,68 @@ spec:
                   ibmcloud:
                     description: ibmcloud contains settings specific to the IBMCloud
                       infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: |-
+                          serviceEndpoints is a list of custom endpoints which will override the default
+                          service endpoints of an IBM service. These endpoints are used by components
+                          within the cluster when trying to reach the IBM Cloud Services that have been
+                          overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                          endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                          are updated to reflect the same custom endpoints.
+                          A maximum of 13 service endpoints overrides are supported.
+                        items:
+                          description: |-
+                            IBMCloudServiceEndpoint stores the configuration of a custom url to
+                            override existing defaults of IBM Cloud Services.
+                          properties:
+                            name:
+                              description: |-
+                                name is the name of the IBM Cloud service.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                For example, the IBM Cloud Private IAM service could be configured with the
+                                service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                              enum:
+                              - CIS
+                              - COS
+                              - COSConfig
+                              - DNSServices
+                              - GlobalCatalog
+                              - GlobalSearch
+                              - GlobalTagging
+                              - HyperProtect
+                              - IAM
+                              - KeyProtect
+                              - ResourceController
+                              - ResourceManager
+                              - VPC
+                              type: string
+                            url:
+                              description: |-
+                                url is fully qualified URI with scheme https, that overrides the default generated
+                                endpoint for a client.
+                                This must be provided and cannot be empty. The path must follow the pattern
+                                /v[0,9]+ or /api/v[0,9]+
+                              maxLength: 300
+                              type: string
+                              x-kubernetes-validations:
+                              - message: url must use https scheme
+                                rule: url(self).getScheme() == "https"
+                              - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                rule: matches((url(self).getEscapedPath()), '^/(api/)?v[0-9]+/{0,1}$')
+                              - message: url must be a valid absolute URL
+                                rule: isURL(self)
+                          required:
+                          - name
+                          - url
+                          type: object
+                        maxItems: 13
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   kubevirt:
                     description: kubevirt contains settings specific to the kubevirt
@@ -324,14 +385,19 @@ spec:
                                     is Name, and forbidden otherwise
                                   rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
                                     : !has(self.name)'
+                              maxItems: 32
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: each subnet must be unique
+                                rule: self.all(x, self.exists_one(y, x == y))
                           required:
                           - cluster
                           - name
                           - subnets
                           type: object
+                        maxItems: 32
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -660,6 +726,10 @@ spec:
                               - type
                               type: object
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -714,6 +784,7 @@ spec:
                                     /<datacenter>/network/<portgroup>.
                                   items:
                                     type: string
+                                  maxItems: 10
                                   minItems: 1
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -822,6 +893,17 @@ spec:
                           - topology
                           - zone
                           type: object
+                          x-kubernetes-validations:
+                          - message: when zoneAffinity type is HostGroup, regionAffinity
+                              type must be ComputeCluster
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''HostGroup'' ?  has(self.regionAffinity) && self.regionAffinity.type
+                              == ''ComputeCluster'' : true'
+                          - message: when zoneAffinity type is ComputeCluster, regionAffinity
+                              type must be Datacenter
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''ComputeCluster'' ?  has(self.regionAffinity) &&
+                              self.regionAffinity.type == ''Datacenter'' : true'
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -889,6 +971,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -906,6 +989,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -919,6 +1003,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -936,6 +1021,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -979,6 +1065,10 @@ spec:
                               minimum: 1
                               type: integer
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -1043,6 +1133,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1081,6 +1172,10 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-
@@ -1158,6 +1253,125 @@ spec:
                     description: aws contains settings specific to the Amazon Web
                       Services infrastructure provider.
                     properties:
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        nullable: true
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for AWS
+                          network resources. This controls whether AWS resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       region:
                         description: region holds the default AWS region for new AWS
                           resources created by the cluster.
@@ -1245,6 +1459,109 @@ spec:
                         description: armEndpoint specifies a URL to use for resource
                           management in non-soverign clouds such as Azure Stack.
                         type: string
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1258,6 +1575,21 @@ spec:
                         - AzureGermanCloud
                         - AzureStackCloud
                         type: string
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for Azure
+                          network resources. This controls whether Azure resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       networkResourceGroupName:
                         description: |-
                           networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1342,6 +1674,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1420,6 +1770,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   equinixMetal:
                     description: equinixMetal contains settings specific to the Equinix
                       Metal infrastructure provider.
@@ -1775,6 +2130,7 @@ spec:
                           - name
                           - url
                           type: object
+                        maxItems: 13
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1829,6 +2185,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1881,6 +2255,11 @@ spec:
                               rule: oldSelf == '' || self == oldSelf
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   openstack:
                     description: openstack contains settings specific to the OpenStack
                       infrastructure provider.
@@ -1917,6 +2296,24 @@ spec:
                         description: |-
                           cloudName is the name of the desired OpenStack cloud in the
                           client configuration file (`clouds.yaml`).
+                        type: string
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
                         type: string
                       ingressIP:
                         description: |-
@@ -1996,6 +2393,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   ovirt:
                     description: ovirt contains settings specific to the oVirt infrastructure
                       provider.
@@ -2028,6 +2430,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2084,6 +2504,11 @@ spec:
                           set or honored.  It will be removed in a future release.'
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   powervs:
                     description: powervs contains settings specific to the Power Systems
                       Virtual Servers infrastructure provider.
@@ -2236,6 +2661,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2314,6 +2757,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                 type: object
             type: object
         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -3,11 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -223,6 +222,68 @@ spec:
                   ibmcloud:
                     description: ibmcloud contains settings specific to the IBMCloud
                       infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: |-
+                          serviceEndpoints is a list of custom endpoints which will override the default
+                          service endpoints of an IBM service. These endpoints are used by components
+                          within the cluster when trying to reach the IBM Cloud Services that have been
+                          overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                          endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                          are updated to reflect the same custom endpoints.
+                          A maximum of 13 service endpoints overrides are supported.
+                        items:
+                          description: |-
+                            IBMCloudServiceEndpoint stores the configuration of a custom url to
+                            override existing defaults of IBM Cloud Services.
+                          properties:
+                            name:
+                              description: |-
+                                name is the name of the IBM Cloud service.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                For example, the IBM Cloud Private IAM service could be configured with the
+                                service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                              enum:
+                              - CIS
+                              - COS
+                              - COSConfig
+                              - DNSServices
+                              - GlobalCatalog
+                              - GlobalSearch
+                              - GlobalTagging
+                              - HyperProtect
+                              - IAM
+                              - KeyProtect
+                              - ResourceController
+                              - ResourceManager
+                              - VPC
+                              type: string
+                            url:
+                              description: |-
+                                url is fully qualified URI with scheme https, that overrides the default generated
+                                endpoint for a client.
+                                This must be provided and cannot be empty. The path must follow the pattern
+                                /v[0,9]+ or /api/v[0,9]+
+                              maxLength: 300
+                              type: string
+                              x-kubernetes-validations:
+                              - message: url must use https scheme
+                                rule: url(self).getScheme() == "https"
+                              - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                rule: matches((url(self).getEscapedPath()), '^/(api/)?v[0-9]+/{0,1}$')
+                              - message: url must be a valid absolute URL
+                                rule: isURL(self)
+                          required:
+                          - name
+                          - url
+                          type: object
+                        maxItems: 13
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   kubevirt:
                     description: kubevirt contains settings specific to the kubevirt
@@ -324,14 +385,19 @@ spec:
                                     is Name, and forbidden otherwise
                                   rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
                                     : !has(self.name)'
+                              maxItems: 32
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: each subnet must be unique
+                                rule: self.all(x, self.exists_one(y, x == y))
                           required:
                           - cluster
                           - name
                           - subnets
                           type: object
+                        maxItems: 32
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -660,6 +726,10 @@ spec:
                               - type
                               type: object
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -714,6 +784,7 @@ spec:
                                     /<datacenter>/network/<portgroup>.
                                   items:
                                     type: string
+                                  maxItems: 10
                                   minItems: 1
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -822,6 +893,17 @@ spec:
                           - topology
                           - zone
                           type: object
+                          x-kubernetes-validations:
+                          - message: when zoneAffinity type is HostGroup, regionAffinity
+                              type must be ComputeCluster
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''HostGroup'' ?  has(self.regionAffinity) && self.regionAffinity.type
+                              == ''ComputeCluster'' : true'
+                          - message: when zoneAffinity type is ComputeCluster, regionAffinity
+                              type must be Datacenter
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''ComputeCluster'' ?  has(self.regionAffinity) &&
+                              self.regionAffinity.type == ''Datacenter'' : true'
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -889,6 +971,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -906,6 +989,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -919,6 +1003,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -936,6 +1021,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -979,6 +1065,10 @@ spec:
                               minimum: 1
                               type: integer
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -1081,6 +1171,9 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
                 type: string
               platform:
                 description: |-
@@ -1158,6 +1251,125 @@ spec:
                     description: aws contains settings specific to the Amazon Web
                       Services infrastructure provider.
                     properties:
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        nullable: true
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for AWS
+                          network resources. This controls whether AWS resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       region:
                         description: region holds the default AWS region for new AWS
                           resources created by the cluster.
@@ -1245,6 +1457,109 @@ spec:
                         description: armEndpoint specifies a URL to use for resource
                           management in non-soverign clouds such as Azure Stack.
                         type: string
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1258,6 +1573,21 @@ spec:
                         - AzureGermanCloud
                         - AzureStackCloud
                         type: string
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for Azure
+                          network resources. This controls whether Azure resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       networkResourceGroupName:
                         description: |-
                           networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1342,6 +1672,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1420,6 +1768,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   equinixMetal:
                     description: equinixMetal contains settings specific to the Equinix
                       Metal infrastructure provider.
@@ -1775,6 +2128,7 @@ spec:
                           - name
                           - url
                           type: object
+                        maxItems: 13
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1829,6 +2183,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1881,6 +2253,11 @@ spec:
                               rule: oldSelf == '' || self == oldSelf
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   openstack:
                     description: openstack contains settings specific to the OpenStack
                       infrastructure provider.
@@ -1917,6 +2294,24 @@ spec:
                         description: |-
                           cloudName is the name of the desired OpenStack cloud in the
                           client configuration file (`clouds.yaml`).
+                        type: string
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
                         type: string
                       ingressIP:
                         description: |-
@@ -1996,6 +2391,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   ovirt:
                     description: ovirt contains settings specific to the oVirt infrastructure
                       provider.
@@ -2028,6 +2428,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2084,6 +2502,11 @@ spec:
                           set or honored.  It will be removed in a future release.'
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   powervs:
                     description: powervs contains settings specific to the Power Systems
                       Virtual Servers infrastructure provider.
@@ -2236,6 +2659,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2314,6 +2755,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                 type: object
             type: object
         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5,9 +5,8 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
-    release.openshift.io/feature-set: DevPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -3,11 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -223,6 +222,68 @@ spec:
                   ibmcloud:
                     description: ibmcloud contains settings specific to the IBMCloud
                       infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: |-
+                          serviceEndpoints is a list of custom endpoints which will override the default
+                          service endpoints of an IBM service. These endpoints are used by components
+                          within the cluster when trying to reach the IBM Cloud Services that have been
+                          overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                          endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                          are updated to reflect the same custom endpoints.
+                          A maximum of 13 service endpoints overrides are supported.
+                        items:
+                          description: |-
+                            IBMCloudServiceEndpoint stores the configuration of a custom url to
+                            override existing defaults of IBM Cloud Services.
+                          properties:
+                            name:
+                              description: |-
+                                name is the name of the IBM Cloud service.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                For example, the IBM Cloud Private IAM service could be configured with the
+                                service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                              enum:
+                              - CIS
+                              - COS
+                              - COSConfig
+                              - DNSServices
+                              - GlobalCatalog
+                              - GlobalSearch
+                              - GlobalTagging
+                              - HyperProtect
+                              - IAM
+                              - KeyProtect
+                              - ResourceController
+                              - ResourceManager
+                              - VPC
+                              type: string
+                            url:
+                              description: |-
+                                url is fully qualified URI with scheme https, that overrides the default generated
+                                endpoint for a client.
+                                This must be provided and cannot be empty. The path must follow the pattern
+                                /v[0,9]+ or /api/v[0,9]+
+                              maxLength: 300
+                              type: string
+                              x-kubernetes-validations:
+                              - message: url must use https scheme
+                                rule: url(self).getScheme() == "https"
+                              - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                rule: matches((url(self).getEscapedPath()), '^/(api/)?v[0-9]+/{0,1}$')
+                              - message: url must be a valid absolute URL
+                                rule: isURL(self)
+                          required:
+                          - name
+                          - url
+                          type: object
+                        maxItems: 13
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   kubevirt:
                     description: kubevirt contains settings specific to the kubevirt
@@ -324,14 +385,19 @@ spec:
                                     is Name, and forbidden otherwise
                                   rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
                                     : !has(self.name)'
+                              maxItems: 32
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: each subnet must be unique
+                                rule: self.all(x, self.exists_one(y, x == y))
                           required:
                           - cluster
                           - name
                           - subnets
                           type: object
+                        maxItems: 32
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -660,6 +726,10 @@ spec:
                               - type
                               type: object
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -714,6 +784,7 @@ spec:
                                     /<datacenter>/network/<portgroup>.
                                   items:
                                     type: string
+                                  maxItems: 10
                                   minItems: 1
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -822,6 +893,17 @@ spec:
                           - topology
                           - zone
                           type: object
+                          x-kubernetes-validations:
+                          - message: when zoneAffinity type is HostGroup, regionAffinity
+                              type must be ComputeCluster
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''HostGroup'' ?  has(self.regionAffinity) && self.regionAffinity.type
+                              == ''ComputeCluster'' : true'
+                          - message: when zoneAffinity type is ComputeCluster, regionAffinity
+                              type must be Datacenter
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''ComputeCluster'' ?  has(self.regionAffinity) &&
+                              self.regionAffinity.type == ''Datacenter'' : true'
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -889,6 +971,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -906,6 +989,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -919,6 +1003,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -936,6 +1021,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -979,6 +1065,10 @@ spec:
                               minimum: 1
                               type: integer
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -1043,6 +1133,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1081,6 +1172,10 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-
@@ -1158,6 +1253,125 @@ spec:
                     description: aws contains settings specific to the Amazon Web
                       Services infrastructure provider.
                     properties:
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        nullable: true
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for AWS
+                          network resources. This controls whether AWS resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       region:
                         description: region holds the default AWS region for new AWS
                           resources created by the cluster.
@@ -1245,6 +1459,109 @@ spec:
                         description: armEndpoint specifies a URL to use for resource
                           management in non-soverign clouds such as Azure Stack.
                         type: string
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1258,6 +1575,21 @@ spec:
                         - AzureGermanCloud
                         - AzureStackCloud
                         type: string
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for Azure
+                          network resources. This controls whether Azure resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       networkResourceGroupName:
                         description: |-
                           networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1342,6 +1674,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1420,6 +1770,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   equinixMetal:
                     description: equinixMetal contains settings specific to the Equinix
                       Metal infrastructure provider.
@@ -1775,6 +2130,7 @@ spec:
                           - name
                           - url
                           type: object
+                        maxItems: 13
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1829,6 +2185,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1881,6 +2255,11 @@ spec:
                               rule: oldSelf == '' || self == oldSelf
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   openstack:
                     description: openstack contains settings specific to the OpenStack
                       infrastructure provider.
@@ -1917,6 +2296,24 @@ spec:
                         description: |-
                           cloudName is the name of the desired OpenStack cloud in the
                           client configuration file (`clouds.yaml`).
+                        type: string
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
                         type: string
                       ingressIP:
                         description: |-
@@ -1996,6 +2393,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   ovirt:
                     description: ovirt contains settings specific to the oVirt infrastructure
                       provider.
@@ -2028,6 +2430,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2084,6 +2504,11 @@ spec:
                           set or honored.  It will be removed in a future release.'
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   powervs:
                     description: powervs contains settings specific to the Power Systems
                       Virtual Servers infrastructure provider.
@@ -2236,6 +2661,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2314,6 +2757,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                 type: object
             type: object
         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -4,10 +4,9 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -1134,6 +1133,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1175,6 +1175,7 @@ spec:
                 enum:
                 - HighlyAvailable
                 - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -369,6 +369,7 @@ infrastructures.config.openshift.io:
   FeatureGates:
   - AWSClusterHostedDNSInstall
   - AWSDualStackInstall
+  - AdaptableTopology
   - AzureClusterHostedDNSInstall
   - AzureDualStackInstall
   - DualReplica

--- a/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -373,6 +373,7 @@ infrastructures.config.openshift.io:
   - AzureClusterHostedDNSInstall
   - AzureDualStackInstall
   - DualReplica
+  - DualReplica+AdaptableTopology
   - DyanmicServiceEndpointIBMCloud
   - NutanixMultiSubnets
   - OnPremDNSRecords

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNSInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNSInstall.yaml
@@ -1075,9 +1075,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSDualStackInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSDualStackInstall.yaml
@@ -1075,9 +1075,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AdaptableTopology.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AdaptableTopology.yaml
@@ -6,7 +6,7 @@ metadata:
     api.openshift.io/filename-cvo-runlevel: "0000_10"
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    feature-gate.release.openshift.io/AdaptableTopology: "true"
     release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
@@ -1043,6 +1043,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1081,6 +1082,10 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureClusterHostedDNSInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureClusterHostedDNSInstall.yaml
@@ -1075,9 +1075,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureDualStackInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureDualStackInstall.yaml
@@ -1075,9 +1075,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica+AdaptableTopology.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica+AdaptableTopology.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/filename-cvo-runlevel: "0000_10"
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
+    feature-gate.release.openshift.io/AdaptableTopology: "true"
     feature-gate.release.openshift.io/DualReplica: "true"
     release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
@@ -1043,6 +1044,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1081,6 +1083,10 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -1137,9 +1137,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -1080,9 +1080,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/OnPremDNSRecords.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/OnPremDNSRecords.yaml
@@ -1075,9 +1075,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -1086,9 +1086,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -1076,9 +1076,6 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
-                enum:
-                - HighlyAvailable
-                - SingleReplica
                 type: string
               platform:
                 description: |-

--- a/features.md
+++ b/features.md
@@ -6,6 +6,7 @@
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | | | |  |
 | MultiArchInstallAzure| | | | | | | |  |
 | ShortCertRotation| | | | | | | |  |
+| AdaptableTopology| | | | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ClusterAPIComputeInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ClusterAPIControlPlaneInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ClusterUpdatePreflight| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |

--- a/features/features.go
+++ b/features/features.go
@@ -115,6 +115,14 @@ var (
 					enable(inDefault(), inOKD(), inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
 					mustRegister()
 
+	FeatureGateAdaptableTopology = newFeatureGate("AdaptableTopology").
+					reportProblemsToJiraComponent("Adaptable Topology").
+					contactPerson("jaypoulz").
+					productScope(ocpSpecific).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1905").
+					enable(inClusterProfile(SelfManaged), inDevPreviewNoUpgrade()).
+					mustRegister()
+
 	FeatureGateAzureWorkloadIdentity = newFeatureGate("AzureWorkloadIdentity").
 						reportProblemsToJiraComponent("cloud-credential-operator").
 						contactPerson("abutcher").

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/AdaptableTopology.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/AdaptableTopology.yaml
@@ -1,0 +1,201 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Optimistically missing"
+crdName: controllerconfigs.machineconfiguration.openshift.io
+featureGates:
+- AdaptableTopology
+tests:
+  onCreate:
+    - name: Should be able to create a ControllerConfig with controlPlaneTopology Adaptable
+      initial: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: Adaptable
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+      expected: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: Adaptable
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+    - name: Should be able to create a ControllerConfig with infrastructureTopology Adaptable
+      initial: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: HighlyAvailable
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: Adaptable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+      expected: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: HighlyAvailable
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: Adaptable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/DualReplica+AdaptableTopology.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/DualReplica+AdaptableTopology.yaml
@@ -1,0 +1,202 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Optimistically missing"
+crdName: controllerconfigs.machineconfiguration.openshift.io
+featureGates:
+- DualReplica
+- AdaptableTopology
+tests:
+  onCreate:
+    - name: Should be able to create a ControllerConfig with controlPlaneTopology Adaptable
+      initial: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: Adaptable
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+      expected: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: Adaptable
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+    - name: Should be able to create a ControllerConfig with controlPlaneTopology DualReplica
+      initial: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: DualReplica
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+      expected: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: DualReplica
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,13 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - Adaptable
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1465,10 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1547,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1754,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1870,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1971,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2067,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2435,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2490,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2560,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2602,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2699,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2737,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2812,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2970,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3066,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -5,8 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,12 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1464,9 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1545,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1752,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1868,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1969,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2065,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2433,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2488,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2558,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2600,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2697,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2735,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2810,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2968,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3064,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -4,9 +4,8 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: DevPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -1427,6 +1426,7 @@ spec:
                         - HighlyAvailableArbiter
                         - SingleReplica
                         - DualReplica
+                        - Adaptable
                         - External
                         type: string
                       cpuPartitioning:
@@ -1468,6 +1468,7 @@ spec:
                         enum:
                         - HighlyAvailable
                         - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,13 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - Adaptable
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1465,10 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1547,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1754,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1870,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1971,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2067,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2435,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2490,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2560,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2602,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2699,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2737,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2812,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2970,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3066,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,12 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1464,9 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1545,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1752,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1868,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1969,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2065,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2433,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2488,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2558,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2600,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2697,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2735,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2810,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2968,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3064,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -32,6 +32,7 @@ controllerconfigs.machineconfiguration.openshift.io:
   - AWSClusterHostedDNSInstall
   - AWSDualStackInstall
   - AWSEuropeanSovereignCloudInstall
+  - AdaptableTopology
   - AzureClusterHostedDNSInstall
   - AzureDualStackInstall
   - DualReplica

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -36,6 +36,7 @@ controllerconfigs.machineconfiguration.openshift.io:
   - AzureClusterHostedDNSInstall
   - AzureDualStackInstall
   - DualReplica
+  - DualReplica+AdaptableTopology
   - DyanmicServiceEndpointIBMCloud
   - NutanixMultiSubnets
   - OnPremDNSRecords

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNSInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNSInstall.yaml
@@ -1372,9 +1372,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
@@ -1376,9 +1376,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AdaptableTopology.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AdaptableTopology.yaml
@@ -6,7 +6,7 @@ metadata:
     api.openshift.io/filename-cvo-runlevel: "0000_80"
     api.openshift.io/filename-operator: machine-config
     api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    feature-gate.release.openshift.io/AdaptableTopology: "true"
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -1335,6 +1335,13 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - Adaptable
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1379,10 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-
@@ -1450,21 +1461,6 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
-                              ipFamily:
-                                default: IPv4
-                                description: |-
-                                  ipFamily specifies the IP protocol family that should be used for AWS
-                                  network resources. This controls whether AWS resources are created with
-                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
-                                  protocol family.
-                                enum:
-                                - IPv4
-                                - DualStackIPv6Primary
-                                - DualStackIPv4Primary
-                                type: string
-                                x-kubernetes-validations:
-                                - message: ipFamily is immutable once set
-                                  rule: oldSelf == '' || self == oldSelf
                               region:
                                 description: region holds the default AWS region for
                                   new AWS resources created by the cluster.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureClusterHostedDNSInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureClusterHostedDNSInstall.yaml
@@ -1372,9 +1372,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureDualStackInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureDualStackInstall.yaml
@@ -1372,9 +1372,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica+AdaptableTopology.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica+AdaptableTopology.yaml
@@ -3,10 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    api.openshift.io/filename-cvo-runlevel: "0000_80"
+    api.openshift.io/filename-operator: machine-config
+    api.openshift.io/filename-ordering: "01"
+    feature-gate.release.openshift.io/AdaptableTopology: "true"
+    feature-gate.release.openshift.io/DualReplica: "true"
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,10 +135,6 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
-                                x-kubernetes-validations:
-                                - message: 'privateZoneIAMRole must be a valid AWS
-                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
-                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -510,69 +507,6 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
-                            properties:
-                              serviceEndpoints:
-                                description: |-
-                                  serviceEndpoints is a list of custom endpoints which will override the default
-                                  service endpoints of an IBM service. These endpoints are used by components
-                                  within the cluster when trying to reach the IBM Cloud Services that have been
-                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
-                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
-                                  are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
-                                items:
-                                  description: |-
-                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
-                                    override existing defaults of IBM Cloud Services.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
-                                        For example, the IBM Cloud Private IAM service could be configured with the
-                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
-                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
-                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
-                                      enum:
-                                      - CIS
-                                      - COS
-                                      - COSConfig
-                                      - DNSServices
-                                      - GlobalCatalog
-                                      - GlobalSearch
-                                      - GlobalTagging
-                                      - HyperProtect
-                                      - IAM
-                                      - KeyProtect
-                                      - ResourceController
-                                      - ResourceManager
-                                      - VPC
-                                      type: string
-                                    url:
-                                      description: |-
-                                        url is fully qualified URI with scheme https, that overrides the default generated
-                                        endpoint for a client.
-                                        This must be provided and cannot be empty. The path must follow the pattern
-                                        /v[0,9]+ or /api/v[0,9]+
-                                      maxLength: 300
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: url must use https scheme
-                                        rule: url(self).getScheme() == "https"
-                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
-                                        rule: matches((url(self).getEscapedPath()),
-                                          '^/(api/)?v[0-9]+/{0,1}$')
-                                      - message: url must be a valid absolute URL
-                                        rule: isURL(self)
-                                  required:
-                                  - name
-                                  - url
-                                  type: object
-                                maxItems: 13
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                - name
-                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -677,20 +611,14 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
-                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
-                                      x-kubernetes-validations:
-                                      - message: each subnet must be unique
-                                        rule: self.all(x, self.exists_one(y, x ==
-                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
-                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1078,7 +1006,6 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
-                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1187,19 +1114,6 @@ spec:
                                   - topology
                                   - zone
                                   type: object
-                                  x-kubernetes-validations:
-                                  - message: when zoneAffinity type is HostGroup,
-                                      regionAffinity type must be ComputeCluster
-                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
-                                      == ''HostGroup'' ?  has(self.regionAffinity)
-                                      && self.regionAffinity.type == ''ComputeCluster''
-                                      : true'
-                                  - message: when zoneAffinity type is ComputeCluster,
-                                      regionAffinity type must be Datacenter
-                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
-                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
-                                      && self.regionAffinity.type == ''Datacenter''
-                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1427,6 +1341,7 @@ spec:
                         - HighlyAvailableArbiter
                         - SingleReplica
                         - DualReplica
+                        - Adaptable
                         - External
                         type: string
                       cpuPartitioning:
@@ -1468,6 +1383,7 @@ spec:
                         enum:
                         - HighlyAvailable
                         - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-
@@ -1546,125 +1462,6 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
-                              cloudLoadBalancerConfig:
-                                default:
-                                  dnsType: PlatformDefault
-                                description: |-
-                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
-                                  load balancers. It allows configuration of in-cluster DNS as an alternative
-                                  to the platform default DNS implementation.
-                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
-                                  must be provided for the API and internal API load balancers as well as the
-                                  ingress load balancer.
-                                nullable: true
-                                properties:
-                                  clusterHosted:
-                                    description: |-
-                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
-                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
-                                      use these IP addresses to provide resolution for API, API-Int and Ingress
-                                      services.
-                                    properties:
-                                      apiIntLoadBalancerIPs:
-                                        description: |-
-                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
-                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
-                                          Entries in the apiIntLoadBalancerIPs must be unique.
-                                          A maximum of 16 IP addresses are permitted.
-                                        format: ip
-                                        items:
-                                          description: IP is an IP address (for example,
-                                            "10.0.0.0" or "fd00::").
-                                          maxLength: 39
-                                          minLength: 1
-                                          type: string
-                                          x-kubernetes-validations:
-                                          - message: value must be a valid IP address
-                                            rule: isIP(self)
-                                        maxItems: 16
-                                        type: array
-                                        x-kubernetes-list-type: set
-                                      apiLoadBalancerIPs:
-                                        description: |-
-                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
-                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
-                                          Could be empty for private clusters.
-                                          Entries in the apiLoadBalancerIPs must be unique.
-                                          A maximum of 16 IP addresses are permitted.
-                                        format: ip
-                                        items:
-                                          description: IP is an IP address (for example,
-                                            "10.0.0.0" or "fd00::").
-                                          maxLength: 39
-                                          minLength: 1
-                                          type: string
-                                          x-kubernetes-validations:
-                                          - message: value must be a valid IP address
-                                            rule: isIP(self)
-                                        maxItems: 16
-                                        type: array
-                                        x-kubernetes-list-type: set
-                                      ingressLoadBalancerIPs:
-                                        description: |-
-                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
-                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
-                                          Entries in the ingressLoadBalancerIPs must be unique.
-                                          A maximum of 16 IP addresses are permitted.
-                                        format: ip
-                                        items:
-                                          description: IP is an IP address (for example,
-                                            "10.0.0.0" or "fd00::").
-                                          maxLength: 39
-                                          minLength: 1
-                                          type: string
-                                          x-kubernetes-validations:
-                                          - message: value must be a valid IP address
-                                            rule: isIP(self)
-                                        maxItems: 16
-                                        type: array
-                                        x-kubernetes-list-type: set
-                                    type: object
-                                  dnsType:
-                                    default: PlatformDefault
-                                    description: |-
-                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
-                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
-                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
-                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
-                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
-                                      The value is immutable after it has been set at install time.
-                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
-                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
-                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
-                                      and it can be run in addition to the in-cluster DNS solution.
-                                    enum:
-                                    - ClusterHosted
-                                    - PlatformDefault
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: dnsType is immutable
-                                      rule: oldSelf == '' || self == oldSelf
-                                type: object
-                                x-kubernetes-validations:
-                                - message: clusterHosted is permitted only when dnsType
-                                    is ClusterHosted
-                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
-                                    ? !has(self.clusterHosted) : true'
-                              ipFamily:
-                                default: IPv4
-                                description: |-
-                                  ipFamily specifies the IP protocol family that should be used for AWS
-                                  network resources. This controls whether AWS resources are created with
-                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
-                                  protocol family.
-                                enum:
-                                - IPv4
-                                - DualStackIPv6Primary
-                                - DualStackIPv4Primary
-                                type: string
-                                x-kubernetes-validations:
-                                - message: ipFamily is immutable once set
-                                  rule: oldSelf == '' || self == oldSelf
                               region:
                                 description: region holds the default AWS region for
                                   new AWS resources created by the cluster.
@@ -1753,109 +1550,6 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
-                              cloudLoadBalancerConfig:
-                                default:
-                                  dnsType: PlatformDefault
-                                description: |-
-                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
-                                  load balancers. It allows configuration of in-cluster DNS as an alternative
-                                  to the platform default DNS implementation.
-                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
-                                  must be provided for the API and internal API load balancers as well as the
-                                  ingress load balancer.
-                                properties:
-                                  clusterHosted:
-                                    description: |-
-                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
-                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
-                                      use these IP addresses to provide resolution for API, API-Int and Ingress
-                                      services.
-                                    properties:
-                                      apiIntLoadBalancerIPs:
-                                        description: |-
-                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
-                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
-                                          Entries in the apiIntLoadBalancerIPs must be unique.
-                                          A maximum of 16 IP addresses are permitted.
-                                        format: ip
-                                        items:
-                                          description: IP is an IP address (for example,
-                                            "10.0.0.0" or "fd00::").
-                                          maxLength: 39
-                                          minLength: 1
-                                          type: string
-                                          x-kubernetes-validations:
-                                          - message: value must be a valid IP address
-                                            rule: isIP(self)
-                                        maxItems: 16
-                                        type: array
-                                        x-kubernetes-list-type: set
-                                      apiLoadBalancerIPs:
-                                        description: |-
-                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
-                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
-                                          Could be empty for private clusters.
-                                          Entries in the apiLoadBalancerIPs must be unique.
-                                          A maximum of 16 IP addresses are permitted.
-                                        format: ip
-                                        items:
-                                          description: IP is an IP address (for example,
-                                            "10.0.0.0" or "fd00::").
-                                          maxLength: 39
-                                          minLength: 1
-                                          type: string
-                                          x-kubernetes-validations:
-                                          - message: value must be a valid IP address
-                                            rule: isIP(self)
-                                        maxItems: 16
-                                        type: array
-                                        x-kubernetes-list-type: set
-                                      ingressLoadBalancerIPs:
-                                        description: |-
-                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
-                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
-                                          Entries in the ingressLoadBalancerIPs must be unique.
-                                          A maximum of 16 IP addresses are permitted.
-                                        format: ip
-                                        items:
-                                          description: IP is an IP address (for example,
-                                            "10.0.0.0" or "fd00::").
-                                          maxLength: 39
-                                          minLength: 1
-                                          type: string
-                                          x-kubernetes-validations:
-                                          - message: value must be a valid IP address
-                                            rule: isIP(self)
-                                        maxItems: 16
-                                        type: array
-                                        x-kubernetes-list-type: set
-                                    type: object
-                                  dnsType:
-                                    default: PlatformDefault
-                                    description: |-
-                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
-                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
-                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
-                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
-                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
-                                      The value is immutable after it has been set at install time.
-                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
-                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
-                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
-                                      and it can be run in addition to the in-cluster DNS solution.
-                                    enum:
-                                    - ClusterHosted
-                                    - PlatformDefault
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: dnsType is immutable
-                                      rule: oldSelf == '' || self == oldSelf
-                                type: object
-                                x-kubernetes-validations:
-                                - message: clusterHosted is permitted only when dnsType
-                                    is ClusterHosted
-                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
-                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1869,21 +1563,6 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
-                              ipFamily:
-                                default: IPv4
-                                description: |-
-                                  ipFamily specifies the IP protocol family that should be used for Azure
-                                  network resources. This controls whether Azure resources are created with
-                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
-                                  protocol family.
-                                enum:
-                                - IPv4
-                                - DualStackIPv6Primary
-                                - DualStackIPv4Primary
-                                type: string
-                                x-kubernetes-validations:
-                                - message: ipFamily is immutable once set
-                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1970,24 +1649,6 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
-                              dnsRecordsType:
-                                description: |-
-                                  dnsRecordsType determines whether records for api, api-int, and ingress
-                                  are provided by the internal DNS service or externally.
-                                  Allowed values are `Internal`, `External`, and omitted.
-                                  When set to `Internal`, records are provided by the internal infrastructure and
-                                  no additional user configuration is required for the cluster to function.
-                                  When set to `External`, records are not provided by the internal infrastructure
-                                  and must be configured by the user on a DNS server outside the cluster.
-                                  Cluster nodes must use this external server for their upstream DNS requests.
-                                  This value may only be set when loadBalancer.type is set to UserManaged.
-                                  When omitted, this means the user has no opinion and the platform is left
-                                  to choose reasonable defaults. These defaults are subject to change over time.
-                                  The current default is `Internal`.
-                                enum:
-                                - Internal
-                                - External
-                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2066,12 +1727,6 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                            - message: dnsRecordsType may only be set to External
-                                when loadBalancer.type is UserManaged
-                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
-                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
-                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2434,7 +2089,6 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2489,24 +2143,6 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
-                              dnsRecordsType:
-                                description: |-
-                                  dnsRecordsType determines whether records for api, api-int, and ingress
-                                  are provided by the internal DNS service or externally.
-                                  Allowed values are `Internal`, `External`, and omitted.
-                                  When set to `Internal`, records are provided by the internal infrastructure and
-                                  no additional user configuration is required for the cluster to function.
-                                  When set to `External`, records are not provided by the internal infrastructure
-                                  and must be configured by the user on a DNS server outside the cluster.
-                                  Cluster nodes must use this external server for their upstream DNS requests.
-                                  This value may only be set when loadBalancer.type is set to UserManaged.
-                                  When omitted, this means the user has no opinion and the platform is left
-                                  to choose reasonable defaults. These defaults are subject to change over time.
-                                  The current default is `Internal`.
-                                enum:
-                                - Internal
-                                - External
-                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2559,12 +2195,6 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
-                            x-kubernetes-validations:
-                            - message: dnsRecordsType may only be set to External
-                                when loadBalancer.type is UserManaged
-                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
-                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
-                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2601,24 +2231,6 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
-                                type: string
-                              dnsRecordsType:
-                                description: |-
-                                  dnsRecordsType determines whether records for api, api-int, and ingress
-                                  are provided by the internal DNS service or externally.
-                                  Allowed values are `Internal`, `External`, and omitted.
-                                  When set to `Internal`, records are provided by the internal infrastructure and
-                                  no additional user configuration is required for the cluster to function.
-                                  When set to `External`, records are not provided by the internal infrastructure
-                                  and must be configured by the user on a DNS server outside the cluster.
-                                  Cluster nodes must use this external server for their upstream DNS requests.
-                                  This value may only be set when loadBalancer.type is set to UserManaged.
-                                  When omitted, this means the user has no opinion and the platform is left
-                                  to choose reasonable defaults. These defaults are subject to change over time.
-                                  The current default is `Internal`.
-                                enum:
-                                - Internal
-                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2698,12 +2310,6 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                            - message: dnsRecordsType may only be set to External
-                                when loadBalancer.type is UserManaged
-                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
-                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
-                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2736,24 +2342,6 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
-                              dnsRecordsType:
-                                description: |-
-                                  dnsRecordsType determines whether records for api, api-int, and ingress
-                                  are provided by the internal DNS service or externally.
-                                  Allowed values are `Internal`, `External`, and omitted.
-                                  When set to `Internal`, records are provided by the internal infrastructure and
-                                  no additional user configuration is required for the cluster to function.
-                                  When set to `External`, records are not provided by the internal infrastructure
-                                  and must be configured by the user on a DNS server outside the cluster.
-                                  Cluster nodes must use this external server for their upstream DNS requests.
-                                  This value may only be set when loadBalancer.type is set to UserManaged.
-                                  When omitted, this means the user has no opinion and the platform is left
-                                  to choose reasonable defaults. These defaults are subject to change over time.
-                                  The current default is `Internal`.
-                                enum:
-                                - Internal
-                                - External
-                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2811,12 +2399,6 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                            - message: dnsRecordsType may only be set to External
-                                when loadBalancer.type is UserManaged
-                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
-                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
-                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2969,24 +2551,6 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
-                              dnsRecordsType:
-                                description: |-
-                                  dnsRecordsType determines whether records for api, api-int, and ingress
-                                  are provided by the internal DNS service or externally.
-                                  Allowed values are `Internal`, `External`, and omitted.
-                                  When set to `Internal`, records are provided by the internal infrastructure and
-                                  no additional user configuration is required for the cluster to function.
-                                  When set to `External`, records are not provided by the internal infrastructure
-                                  and must be configured by the user on a DNS server outside the cluster.
-                                  Cluster nodes must use this external server for their upstream DNS requests.
-                                  This value may only be set when loadBalancer.type is set to UserManaged.
-                                  When omitted, this means the user has no opinion and the platform is left
-                                  to choose reasonable defaults. These defaults are subject to change over time.
-                                  The current default is `Internal`.
-                                enum:
-                                - Internal
-                                - External
-                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -3065,12 +2629,6 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                            - message: dnsRecordsType may only be set to External
-                                when loadBalancer.type is UserManaged
-                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
-                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
-                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica.yaml
@@ -1378,9 +1378,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -1435,9 +1435,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -1378,9 +1378,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/OnPremDNSRecords.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/OnPremDNSRecords.yaml
@@ -1372,9 +1372,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -1385,9 +1385,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -1373,9 +1373,6 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
-                        enum:
-                        - HighlyAvailable
-                        - SingleReplica
                         type: string
                       platform:
                         description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
@@ -3,11 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -223,6 +222,68 @@ spec:
                   ibmcloud:
                     description: ibmcloud contains settings specific to the IBMCloud
                       infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: |-
+                          serviceEndpoints is a list of custom endpoints which will override the default
+                          service endpoints of an IBM service. These endpoints are used by components
+                          within the cluster when trying to reach the IBM Cloud Services that have been
+                          overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                          endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                          are updated to reflect the same custom endpoints.
+                          A maximum of 13 service endpoints overrides are supported.
+                        items:
+                          description: |-
+                            IBMCloudServiceEndpoint stores the configuration of a custom url to
+                            override existing defaults of IBM Cloud Services.
+                          properties:
+                            name:
+                              description: |-
+                                name is the name of the IBM Cloud service.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                For example, the IBM Cloud Private IAM service could be configured with the
+                                service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                              enum:
+                              - CIS
+                              - COS
+                              - COSConfig
+                              - DNSServices
+                              - GlobalCatalog
+                              - GlobalSearch
+                              - GlobalTagging
+                              - HyperProtect
+                              - IAM
+                              - KeyProtect
+                              - ResourceController
+                              - ResourceManager
+                              - VPC
+                              type: string
+                            url:
+                              description: |-
+                                url is fully qualified URI with scheme https, that overrides the default generated
+                                endpoint for a client.
+                                This must be provided and cannot be empty. The path must follow the pattern
+                                /v[0,9]+ or /api/v[0,9]+
+                              maxLength: 300
+                              type: string
+                              x-kubernetes-validations:
+                              - message: url must use https scheme
+                                rule: url(self).getScheme() == "https"
+                              - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                rule: matches((url(self).getEscapedPath()), '^/(api/)?v[0-9]+/{0,1}$')
+                              - message: url must be a valid absolute URL
+                                rule: isURL(self)
+                          required:
+                          - name
+                          - url
+                          type: object
+                        maxItems: 13
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   kubevirt:
                     description: kubevirt contains settings specific to the kubevirt
@@ -324,14 +385,19 @@ spec:
                                     is Name, and forbidden otherwise
                                   rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
                                     : !has(self.name)'
+                              maxItems: 32
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: each subnet must be unique
+                                rule: self.all(x, self.exists_one(y, x == y))
                           required:
                           - cluster
                           - name
                           - subnets
                           type: object
+                        maxItems: 32
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -660,6 +726,10 @@ spec:
                               - type
                               type: object
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -714,6 +784,7 @@ spec:
                                     /<datacenter>/network/<portgroup>.
                                   items:
                                     type: string
+                                  maxItems: 10
                                   minItems: 1
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -822,6 +893,17 @@ spec:
                           - topology
                           - zone
                           type: object
+                          x-kubernetes-validations:
+                          - message: when zoneAffinity type is HostGroup, regionAffinity
+                              type must be ComputeCluster
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''HostGroup'' ?  has(self.regionAffinity) && self.regionAffinity.type
+                              == ''ComputeCluster'' : true'
+                          - message: when zoneAffinity type is ComputeCluster, regionAffinity
+                              type must be Datacenter
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''ComputeCluster'' ?  has(self.regionAffinity) &&
+                              self.regionAffinity.type == ''Datacenter'' : true'
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -889,6 +971,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -906,6 +989,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -919,6 +1003,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -936,6 +1021,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -979,6 +1065,10 @@ spec:
                               minimum: 1
                               type: integer
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -1043,6 +1133,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1081,6 +1172,10 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-
@@ -1158,6 +1253,125 @@ spec:
                     description: aws contains settings specific to the Amazon Web
                       Services infrastructure provider.
                     properties:
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        nullable: true
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for AWS
+                          network resources. This controls whether AWS resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       region:
                         description: region holds the default AWS region for new AWS
                           resources created by the cluster.
@@ -1245,6 +1459,109 @@ spec:
                         description: armEndpoint specifies a URL to use for resource
                           management in non-soverign clouds such as Azure Stack.
                         type: string
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1258,6 +1575,21 @@ spec:
                         - AzureGermanCloud
                         - AzureStackCloud
                         type: string
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for Azure
+                          network resources. This controls whether Azure resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       networkResourceGroupName:
                         description: |-
                           networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1342,6 +1674,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1420,6 +1770,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   equinixMetal:
                     description: equinixMetal contains settings specific to the Equinix
                       Metal infrastructure provider.
@@ -1775,6 +2130,7 @@ spec:
                           - name
                           - url
                           type: object
+                        maxItems: 13
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1829,6 +2185,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1881,6 +2255,11 @@ spec:
                               rule: oldSelf == '' || self == oldSelf
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   openstack:
                     description: openstack contains settings specific to the OpenStack
                       infrastructure provider.
@@ -1917,6 +2296,24 @@ spec:
                         description: |-
                           cloudName is the name of the desired OpenStack cloud in the
                           client configuration file (`clouds.yaml`).
+                        type: string
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
                         type: string
                       ingressIP:
                         description: |-
@@ -1996,6 +2393,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   ovirt:
                     description: ovirt contains settings specific to the oVirt infrastructure
                       provider.
@@ -2028,6 +2430,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2084,6 +2504,11 @@ spec:
                           set or honored.  It will be removed in a future release.'
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   powervs:
                     description: powervs contains settings specific to the Power Systems
                       Virtual Servers infrastructure provider.
@@ -2236,6 +2661,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2314,6 +2757,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                 type: object
             type: object
         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -3,11 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -223,6 +222,68 @@ spec:
                   ibmcloud:
                     description: ibmcloud contains settings specific to the IBMCloud
                       infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: |-
+                          serviceEndpoints is a list of custom endpoints which will override the default
+                          service endpoints of an IBM service. These endpoints are used by components
+                          within the cluster when trying to reach the IBM Cloud Services that have been
+                          overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                          endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                          are updated to reflect the same custom endpoints.
+                          A maximum of 13 service endpoints overrides are supported.
+                        items:
+                          description: |-
+                            IBMCloudServiceEndpoint stores the configuration of a custom url to
+                            override existing defaults of IBM Cloud Services.
+                          properties:
+                            name:
+                              description: |-
+                                name is the name of the IBM Cloud service.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                For example, the IBM Cloud Private IAM service could be configured with the
+                                service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                              enum:
+                              - CIS
+                              - COS
+                              - COSConfig
+                              - DNSServices
+                              - GlobalCatalog
+                              - GlobalSearch
+                              - GlobalTagging
+                              - HyperProtect
+                              - IAM
+                              - KeyProtect
+                              - ResourceController
+                              - ResourceManager
+                              - VPC
+                              type: string
+                            url:
+                              description: |-
+                                url is fully qualified URI with scheme https, that overrides the default generated
+                                endpoint for a client.
+                                This must be provided and cannot be empty. The path must follow the pattern
+                                /v[0,9]+ or /api/v[0,9]+
+                              maxLength: 300
+                              type: string
+                              x-kubernetes-validations:
+                              - message: url must use https scheme
+                                rule: url(self).getScheme() == "https"
+                              - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                rule: matches((url(self).getEscapedPath()), '^/(api/)?v[0-9]+/{0,1}$')
+                              - message: url must be a valid absolute URL
+                                rule: isURL(self)
+                          required:
+                          - name
+                          - url
+                          type: object
+                        maxItems: 13
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   kubevirt:
                     description: kubevirt contains settings specific to the kubevirt
@@ -324,14 +385,19 @@ spec:
                                     is Name, and forbidden otherwise
                                   rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
                                     : !has(self.name)'
+                              maxItems: 32
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: each subnet must be unique
+                                rule: self.all(x, self.exists_one(y, x == y))
                           required:
                           - cluster
                           - name
                           - subnets
                           type: object
+                        maxItems: 32
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -660,6 +726,10 @@ spec:
                               - type
                               type: object
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -714,6 +784,7 @@ spec:
                                     /<datacenter>/network/<portgroup>.
                                   items:
                                     type: string
+                                  maxItems: 10
                                   minItems: 1
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -822,6 +893,17 @@ spec:
                           - topology
                           - zone
                           type: object
+                          x-kubernetes-validations:
+                          - message: when zoneAffinity type is HostGroup, regionAffinity
+                              type must be ComputeCluster
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''HostGroup'' ?  has(self.regionAffinity) && self.regionAffinity.type
+                              == ''ComputeCluster'' : true'
+                          - message: when zoneAffinity type is ComputeCluster, regionAffinity
+                              type must be Datacenter
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''ComputeCluster'' ?  has(self.regionAffinity) &&
+                              self.regionAffinity.type == ''Datacenter'' : true'
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -889,6 +971,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -906,6 +989,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -919,6 +1003,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -936,6 +1021,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -979,6 +1065,10 @@ spec:
                               minimum: 1
                               type: integer
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -1081,6 +1171,9 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
                 type: string
               platform:
                 description: |-
@@ -1158,6 +1251,125 @@ spec:
                     description: aws contains settings specific to the Amazon Web
                       Services infrastructure provider.
                     properties:
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        nullable: true
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for AWS
+                          network resources. This controls whether AWS resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       region:
                         description: region holds the default AWS region for new AWS
                           resources created by the cluster.
@@ -1245,6 +1457,109 @@ spec:
                         description: armEndpoint specifies a URL to use for resource
                           management in non-soverign clouds such as Azure Stack.
                         type: string
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1258,6 +1573,21 @@ spec:
                         - AzureGermanCloud
                         - AzureStackCloud
                         type: string
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for Azure
+                          network resources. This controls whether Azure resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       networkResourceGroupName:
                         description: |-
                           networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1342,6 +1672,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1420,6 +1768,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   equinixMetal:
                     description: equinixMetal contains settings specific to the Equinix
                       Metal infrastructure provider.
@@ -1775,6 +2128,7 @@ spec:
                           - name
                           - url
                           type: object
+                        maxItems: 13
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1829,6 +2183,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1881,6 +2253,11 @@ spec:
                               rule: oldSelf == '' || self == oldSelf
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   openstack:
                     description: openstack contains settings specific to the OpenStack
                       infrastructure provider.
@@ -1917,6 +2294,24 @@ spec:
                         description: |-
                           cloudName is the name of the desired OpenStack cloud in the
                           client configuration file (`clouds.yaml`).
+                        type: string
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
                         type: string
                       ingressIP:
                         description: |-
@@ -1996,6 +2391,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   ovirt:
                     description: ovirt contains settings specific to the oVirt infrastructure
                       provider.
@@ -2028,6 +2428,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2084,6 +2502,11 @@ spec:
                           set or honored.  It will be removed in a future release.'
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   powervs:
                     description: powervs contains settings specific to the Power Systems
                       Virtual Servers infrastructure provider.
@@ -2236,6 +2659,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2314,6 +2755,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                 type: object
             type: object
         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5,9 +5,8 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
-    release.openshift.io/feature-set: DevPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -3,11 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/DualReplica: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -223,6 +222,68 @@ spec:
                   ibmcloud:
                     description: ibmcloud contains settings specific to the IBMCloud
                       infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: |-
+                          serviceEndpoints is a list of custom endpoints which will override the default
+                          service endpoints of an IBM service. These endpoints are used by components
+                          within the cluster when trying to reach the IBM Cloud Services that have been
+                          overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                          endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                          are updated to reflect the same custom endpoints.
+                          A maximum of 13 service endpoints overrides are supported.
+                        items:
+                          description: |-
+                            IBMCloudServiceEndpoint stores the configuration of a custom url to
+                            override existing defaults of IBM Cloud Services.
+                          properties:
+                            name:
+                              description: |-
+                                name is the name of the IBM Cloud service.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                For example, the IBM Cloud Private IAM service could be configured with the
+                                service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                              enum:
+                              - CIS
+                              - COS
+                              - COSConfig
+                              - DNSServices
+                              - GlobalCatalog
+                              - GlobalSearch
+                              - GlobalTagging
+                              - HyperProtect
+                              - IAM
+                              - KeyProtect
+                              - ResourceController
+                              - ResourceManager
+                              - VPC
+                              type: string
+                            url:
+                              description: |-
+                                url is fully qualified URI with scheme https, that overrides the default generated
+                                endpoint for a client.
+                                This must be provided and cannot be empty. The path must follow the pattern
+                                /v[0,9]+ or /api/v[0,9]+
+                              maxLength: 300
+                              type: string
+                              x-kubernetes-validations:
+                              - message: url must use https scheme
+                                rule: url(self).getScheme() == "https"
+                              - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                rule: matches((url(self).getEscapedPath()), '^/(api/)?v[0-9]+/{0,1}$')
+                              - message: url must be a valid absolute URL
+                                rule: isURL(self)
+                          required:
+                          - name
+                          - url
+                          type: object
+                        maxItems: 13
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                     type: object
                   kubevirt:
                     description: kubevirt contains settings specific to the kubevirt
@@ -324,14 +385,19 @@ spec:
                                     is Name, and forbidden otherwise
                                   rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name)
                                     : !has(self.name)'
+                              maxItems: 32
                               minItems: 1
                               type: array
                               x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: each subnet must be unique
+                                rule: self.all(x, self.exists_one(y, x == y))
                           required:
                           - cluster
                           - name
                           - subnets
                           type: object
+                        maxItems: 32
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -660,6 +726,10 @@ spec:
                               - type
                               type: object
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -714,6 +784,7 @@ spec:
                                     /<datacenter>/network/<portgroup>.
                                   items:
                                     type: string
+                                  maxItems: 10
                                   minItems: 1
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -822,6 +893,17 @@ spec:
                           - topology
                           - zone
                           type: object
+                          x-kubernetes-validations:
+                          - message: when zoneAffinity type is HostGroup, regionAffinity
+                              type must be ComputeCluster
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''HostGroup'' ?  has(self.regionAffinity) && self.regionAffinity.type
+                              == ''ComputeCluster'' : true'
+                          - message: when zoneAffinity type is ComputeCluster, regionAffinity
+                              type must be Datacenter
+                            rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                              == ''ComputeCluster'' ?  has(self.regionAffinity) &&
+                              self.regionAffinity.type == ''Datacenter'' : true'
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -889,6 +971,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -906,6 +989,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -919,6 +1003,7 @@ spec:
                                   excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting
                                   the IP address from the VirtualMachine's VM for use in the status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -936,6 +1021,7 @@ spec:
                                   networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs
                                   that will be used in respective status.addresses fields.
                                 items:
+                                  format: cidr
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: set
@@ -979,6 +1065,10 @@ spec:
                               minimum: 1
                               type: integer
                             server:
+                              anyOf:
+                              - format: ipv4
+                              - format: ipv6
+                              - format: hostname
                               description: server is the fully-qualified domain name
                                 or the IP address of the vCenter server.
                               maxLength: 255
@@ -1043,6 +1133,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1081,6 +1172,10 @@ spec:
                   The 'SingleReplica' mode will be used in single-node deployments
                   and the operators should not configure the operand for highly-available operation
                   NOTE: External topology mode is not applicable for this field.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-
@@ -1158,6 +1253,125 @@ spec:
                     description: aws contains settings specific to the Amazon Web
                       Services infrastructure provider.
                     properties:
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        nullable: true
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for AWS
+                          network resources. This controls whether AWS resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       region:
                         description: region holds the default AWS region for new AWS
                           resources created by the cluster.
@@ -1245,6 +1459,109 @@ spec:
                         description: armEndpoint specifies a URL to use for resource
                           management in non-soverign clouds such as Azure Stack.
                         type: string
+                      cloudLoadBalancerConfig:
+                        default:
+                          dnsType: PlatformDefault
+                        description: |-
+                          cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                          load balancers. It allows configuration of in-cluster DNS as an alternative
+                          to the platform default DNS implementation.
+                          When using the ClusterHosted DNS type, Load Balancer IP addresses
+                          must be provided for the API and internal API load balancers as well as the
+                          ingress load balancer.
+                        properties:
+                          clusterHosted:
+                            description: |-
+                              clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                              Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                              use these IP addresses to provide resolution for API, API-Int and Ingress
+                              services.
+                            properties:
+                              apiIntLoadBalancerIPs:
+                                description: |-
+                                  apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the apiIntLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              apiLoadBalancerIPs:
+                                description: |-
+                                  apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Could be empty for private clusters.
+                                  Entries in the apiLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              ingressLoadBalancerIPs:
+                                description: |-
+                                  ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                  These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                  Entries in the ingressLoadBalancerIPs must be unique.
+                                  A maximum of 16 IP addresses are permitted.
+                                format: ip
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                            type: object
+                          dnsType:
+                            default: PlatformDefault
+                            description: |-
+                              dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                              `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                              It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                              the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                              The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                              The value is immutable after it has been set at install time.
+                              Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                              Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                              installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                              and it can be run in addition to the in-cluster DNS solution.
+                            enum:
+                            - ClusterHosted
+                            - PlatformDefault
+                            type: string
+                            x-kubernetes-validations:
+                            - message: dnsType is immutable
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
+                        x-kubernetes-validations:
+                        - message: clusterHosted is permitted only when dnsType is
+                            ClusterHosted
+                          rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                            ? !has(self.clusterHosted) : true'
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1258,6 +1575,21 @@ spec:
                         - AzureGermanCloud
                         - AzureStackCloud
                         type: string
+                      ipFamily:
+                        default: IPv4
+                        description: |-
+                          ipFamily specifies the IP protocol family that should be used for Azure
+                          network resources. This controls whether Azure resources are created with
+                          IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                          protocol family.
+                        enum:
+                        - IPv4
+                        - DualStackIPv6Primary
+                        - DualStackIPv4Primary
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ipFamily is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
                       networkResourceGroupName:
                         description: |-
                           networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1342,6 +1674,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1420,6 +1770,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   equinixMetal:
                     description: equinixMetal contains settings specific to the Equinix
                       Metal infrastructure provider.
@@ -1775,6 +2130,7 @@ spec:
                           - name
                           - url
                           type: object
+                        maxItems: 13
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1829,6 +2185,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -1881,6 +2255,11 @@ spec:
                               rule: oldSelf == '' || self == oldSelf
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   openstack:
                     description: openstack contains settings specific to the OpenStack
                       infrastructure provider.
@@ -1917,6 +2296,24 @@ spec:
                         description: |-
                           cloudName is the name of the desired OpenStack cloud in the
                           client configuration file (`clouds.yaml`).
+                        type: string
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
                         type: string
                       ingressIP:
                         description: |-
@@ -1996,6 +2393,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   ovirt:
                     description: ovirt contains settings specific to the oVirt infrastructure
                       provider.
@@ -2028,6 +2430,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2084,6 +2504,11 @@ spec:
                           set or honored.  It will be removed in a future release.'
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                   powervs:
                     description: powervs contains settings specific to the Power Systems
                       Virtual Servers infrastructure provider.
@@ -2236,6 +2661,24 @@ spec:
                           rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                             && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                             : true)'
+                      dnsRecordsType:
+                        description: |-
+                          dnsRecordsType determines whether records for api, api-int, and ingress
+                          are provided by the internal DNS service or externally.
+                          Allowed values are `Internal`, `External`, and omitted.
+                          When set to `Internal`, records are provided by the internal infrastructure and
+                          no additional user configuration is required for the cluster to function.
+                          When set to `External`, records are not provided by the internal infrastructure
+                          and must be configured by the user on a DNS server outside the cluster.
+                          Cluster nodes must use this external server for their upstream DNS requests.
+                          This value may only be set when loadBalancer.type is set to UserManaged.
+                          When omitted, this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject to change over time.
+                          The current default is `Internal`.
+                        enum:
+                        - Internal
+                        - External
+                        type: string
                       ingressIP:
                         description: |-
                           ingressIP is an external IP which routes to the default ingress controller.
@@ -2314,6 +2757,11 @@ spec:
                           to the nodes in the cluster.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: dnsRecordsType may only be set to External when loadBalancer.type
+                        is UserManaged
+                      rule: '!has(self.dnsRecordsType) || self.dnsRecordsType == ''Internal''
+                        || (has(self.loadBalancer) && self.loadBalancer.type == ''UserManaged'')'
                 type: object
             type: object
         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -4,10 +4,9 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
@@ -1134,6 +1133,7 @@ spec:
                 - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
+                - Adaptable
                 - External
                 type: string
               cpuPartitioning:
@@ -1175,6 +1175,7 @@ spec:
                 enum:
                 - HighlyAvailable
                 - SingleReplica
+                - Adaptable
                 type: string
               platform:
                 description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
@@ -5,8 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -1427,6 +1426,7 @@ spec:
                         - HighlyAvailableArbiter
                         - SingleReplica
                         - DualReplica
+                        - Adaptable
                         - External
                         type: string
                       cpuPartitioning:
@@ -1468,6 +1468,7 @@ spec:
                         enum:
                         - HighlyAvailable
                         - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -5,8 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,12 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1464,9 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1545,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1752,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1868,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1969,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2065,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2433,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2488,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2558,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2600,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2697,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2735,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2810,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2968,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3064,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -4,9 +4,8 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: DevPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -1427,6 +1426,7 @@ spec:
                         - HighlyAvailableArbiter
                         - SingleReplica
                         - DualReplica
+                        - Adaptable
                         - External
                         type: string
                       cpuPartitioning:
@@ -1468,6 +1468,7 @@ spec:
                         enum:
                         - HighlyAvailable
                         - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,13 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - Adaptable
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1465,10 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - Adaptable
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1547,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1754,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1870,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1971,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2067,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2435,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2490,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2560,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2602,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2699,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2737,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2812,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2970,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3066,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -3,10 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
-    api.openshift.io/filename-cvo-runlevel: "0000_80"
-    api.openshift.io/filename-operator: machine-config
-    api.openshift.io/filename-ordering: "01"
-    feature-gate.release.openshift.io/AWSDualStackInstall: "true"
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -134,6 +133,10 @@ spec:
                                   <account-id> is a 12-digit numeric identifier for the AWS account,
                                   <role-name> is the IAM role name.
                                 type: string
+                                x-kubernetes-validations:
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
                             description: |-
@@ -506,6 +509,69 @@ spec:
                           ibmcloud:
                             description: ibmcloud contains settings specific to the
                               IBMCloud infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: |-
+                                  serviceEndpoints is a list of custom endpoints which will override the default
+                                  service endpoints of an IBM service. These endpoints are used by components
+                                  within the cluster when trying to reach the IBM Cloud Services that have been
+                                  overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
+                                  endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
+                                  are updated to reflect the same custom endpoints.
+                                  A maximum of 13 service endpoints overrides are supported.
+                                items:
+                                  description: |-
+                                    IBMCloudServiceEndpoint stores the configuration of a custom url to
+                                    override existing defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        name is the name of the IBM Cloud service.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service could be configured with the
+                                        service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: |-
+                                        url is fully qualified URI with scheme https, that overrides the default generated
+                                        endpoint for a client.
+                                        This must be provided and cannot be empty. The path must follow the pattern
+                                        /v[0,9]+ or /api/v[0,9]+
+                                      maxLength: 300
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must use https scheme
+                                        rule: url(self).getScheme() == "https"
+                                      - message: url path must match /v[0,9]+ or /api/v[0,9]+
+                                        rule: matches((url(self).getEscapedPath()),
+                                          '^/(api/)?v[0-9]+/{0,1}$')
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                maxItems: 13
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           kubevirt:
                             description: kubevirt contains settings specific to the
@@ -610,14 +676,20 @@ spec:
                                             when type is Name, and forbidden otherwise
                                           rule: 'has(self.type) && self.type == ''Name''
                                             ?  has(self.name) : !has(self.name)'
+                                      maxItems: 32
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                      x-kubernetes-validations:
+                                      - message: each subnet must be unique
+                                        rule: self.all(x, self.exists_one(y, x ==
+                                          y))
                                   required:
                                   - cluster
                                   - name
                                   - subnets
                                   type: object
+                                maxItems: 32
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1005,6 +1077,7 @@ spec:
                                             /<datacenter>/network/<portgroup>.
                                           items:
                                             type: string
+                                          maxItems: 10
                                           minItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
@@ -1113,6 +1186,19 @@ spec:
                                   - topology
                                   - zone
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: when zoneAffinity type is HostGroup,
+                                      regionAffinity type must be ComputeCluster
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''HostGroup'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''ComputeCluster''
+                                      : true'
+                                  - message: when zoneAffinity type is ComputeCluster,
+                                      regionAffinity type must be Datacenter
+                                    rule: 'has(self.zoneAffinity) && self.zoneAffinity.type
+                                      == ''ComputeCluster'' ?  has(self.regionAffinity)
+                                      && self.regionAffinity.type == ''Datacenter''
+                                      : true'
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -1335,6 +1421,12 @@ spec:
                           its components are not visible within the cluster.
                           The 'HighlyAvailableArbiter' mode indicates that the control plane will consist of 2 control-plane nodes
                           that run conventional services and 1 smaller sized arbiter node that runs a bare minimum of services to maintain quorum.
+                        enum:
+                        - HighlyAvailable
+                        - HighlyAvailableArbiter
+                        - SingleReplica
+                        - DualReplica
+                        - External
                         type: string
                       cpuPartitioning:
                         default: None
@@ -1372,6 +1464,9 @@ spec:
                           The 'SingleReplica' mode will be used in single-node deployments
                           and the operators should not configure the operand for highly-available operation
                           NOTE: External topology mode is not applicable for this field.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
                         type: string
                       platform:
                         description: |-
@@ -1450,6 +1545,110 @@ spec:
                             description: aws contains settings specific to the Amazon
                               Web Services infrastructure provider.
                             properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               ipFamily:
                                 default: IPv4
                                 description: |-
@@ -1553,6 +1752,109 @@ spec:
                                   resource management in non-soverign clouds such
                                   as Azure Stack.
                                 type: string
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: |-
+                                  cloudLoadBalancerConfig holds configuration related to DNS and cloud
+                                  load balancers. It allows configuration of in-cluster DNS as an alternative
+                                  to the platform default DNS implementation.
+                                  When using the ClusterHosted DNS type, Load Balancer IP addresses
+                                  must be provided for the API and internal API load balancers as well as the
+                                  ingress load balancer.
+                                properties:
+                                  clusterHosted:
+                                    description: |-
+                                      clusterHosted holds the IP addresses of API, API-Int and Ingress Load
+                                      Balancers on Cloud Platforms. The DNS solution hosted within the cluster
+                                      use these IP addresses to provide resolution for API, API-Int and Ingress
+                                      services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: |-
+                                          apiIntLoadBalancerIPs holds Load Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the apiIntLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: |-
+                                          apiLoadBalancerIPs holds Load Balancer IPs for the API service.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Could be empty for private clusters.
+                                          Entries in the apiLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: |-
+                                          ingressLoadBalancerIPs holds IPs for Ingress Load Balancers.
+                                          These Load Balancer IP addresses can be IPv4 and/or IPv6 addresses.
+                                          Entries in the ingressLoadBalancerIPs must be unique.
+                                          A maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: |-
+                                      dnsType indicates the type of DNS solution in use within the cluster. Its default value of
+                                      `PlatformDefault` indicates that the cluster's DNS is the default provided by the cloud platform.
+                                      It can be set to `ClusterHosted` to bypass the configuration of the cloud default DNS. In this mode,
+                                      the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+                                      The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+                                      The value is immutable after it has been set at install time.
+                                      Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+                                      Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+                                      installation is complete. The customer would be responsible for configuring this custom DNS solution,
+                                      and it can be run in addition to the in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
                               cloudName:
                                 description: |-
                                   cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
@@ -1566,6 +1868,21 @@ spec:
                                 - AzureGermanCloud
                                 - AzureStackCloud
                                 type: string
+                              ipFamily:
+                                default: IPv4
+                                description: |-
+                                  ipFamily specifies the IP protocol family that should be used for Azure
+                                  network resources. This controls whether Azure resources are created with
+                                  IPv4-only, or dual-stack networking with IPv4 or IPv6 as the primary
+                                  protocol family.
+                                enum:
+                                - IPv4
+                                - DualStackIPv6Primary
+                                - DualStackIPv4Primary
+                                type: string
+                                x-kubernetes-validations:
+                                - message: ipFamily is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
                               networkResourceGroupName:
                                 description: |-
                                   networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
@@ -1652,6 +1969,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -1730,6 +2065,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           equinixMetal:
                             description: equinixMetal contains settings specific to
                               the Equinix Metal infrastructure provider.
@@ -2092,6 +2433,7 @@ spec:
                                   - name
                                   - url
                                   type: object
+                                maxItems: 13
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2146,6 +2488,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2198,6 +2558,12 @@ spec:
                                       rule: oldSelf == '' || self == oldSelf
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           openstack:
                             description: openstack contains settings specific to the
                               OpenStack infrastructure provider.
@@ -2234,6 +2600,24 @@ spec:
                                 description: |-
                                   cloudName is the name of the desired OpenStack cloud in the
                                   client configuration file (`clouds.yaml`).
+                                type: string
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
                                 type: string
                               ingressIP:
                                 description: |-
@@ -2313,6 +2697,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           ovirt:
                             description: ovirt contains settings specific to the oVirt
                               infrastructure provider.
@@ -2345,6 +2735,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2402,6 +2810,12 @@ spec:
                                   a future release.'
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                           powervs:
                             description: powervs contains settings specific to the
                               Power Systems Virtual Servers infrastructure provider.
@@ -2554,6 +2968,24 @@ spec:
                                   rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
                                     && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
                                     : true)'
+                              dnsRecordsType:
+                                description: |-
+                                  dnsRecordsType determines whether records for api, api-int, and ingress
+                                  are provided by the internal DNS service or externally.
+                                  Allowed values are `Internal`, `External`, and omitted.
+                                  When set to `Internal`, records are provided by the internal infrastructure and
+                                  no additional user configuration is required for the cluster to function.
+                                  When set to `External`, records are not provided by the internal infrastructure
+                                  and must be configured by the user on a DNS server outside the cluster.
+                                  Cluster nodes must use this external server for their upstream DNS requests.
+                                  This value may only be set when loadBalancer.type is set to UserManaged.
+                                  When omitted, this means the user has no opinion and the platform is left
+                                  to choose reasonable defaults. These defaults are subject to change over time.
+                                  The current default is `Internal`.
+                                enum:
+                                - Internal
+                                - External
+                                type: string
                               ingressIP:
                                 description: |-
                                   ingressIP is an external IP which routes to the default ingress controller.
@@ -2632,6 +3064,12 @@ spec:
                                   to the nodes in the cluster.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: dnsRecordsType may only be set to External
+                                when loadBalancer.type is UserManaged
+                              rule: '!has(self.dnsRecordsType) || self.dnsRecordsType
+                                == ''Internal'' || (has(self.loadBalancer) && self.loadBalancer.type
+                                == ''UserManaged'')'
                         type: object
                     type: object
                 required:

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
@@ -33,6 +33,9 @@
                         "name": "AWSServiceLBNetworkSecurityGroup"
                     },
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "AdditionalStorageConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
@@ -17,6 +17,9 @@
             {
                 "disabled": [
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
@@ -35,6 +35,9 @@
                         "name": "AWSServiceLBNetworkSecurityGroup"
                     },
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "AdditionalStorageConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
@@ -17,6 +17,9 @@
             {
                 "disabled": [
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
@@ -30,6 +30,9 @@
                         "name": "AWSEuropeanSovereignCloudInstall"
                     },
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "AdditionalStorageConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -58,6 +58,9 @@
                         "name": "AWSServiceLBNetworkSecurityGroup"
                     },
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "AdditionalStorageConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
@@ -32,6 +32,9 @@
                         "name": "AWSEuropeanSovereignCloudInstall"
                     },
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "AdditionalStorageConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -17,6 +17,9 @@
             {
                 "disabled": [
                     {
+                        "name": "AdaptableTopology"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {


### PR DESCRIPTION
## Summary

- Add `AdaptableTopology` feature gate (SelfManaged, DevPreviewNoUpgrade) to the Infrastructure API
- Add `Adaptable` enum value to `controlPlaneTopology` and `infrastructureTopology` fields, gated behind `AdaptableTopology`
- Replace static `kubebuilder:validation:Enum` with `FeatureGateAwareEnum` markers so enum validation respects feature gate state
- Add compound `requiredFeatureGate=DualReplica;AdaptableTopology` marker for `controlPlaneTopology` to handle the case where both gates are enabled

## Details

Adaptable Topology enables clusters to dynamically adjust control-plane and infrastructure behavior based on current node count. This PR adds the foundational API types:

1. **Feature gate** — `AdaptableTopology`, scoped to `SelfManaged` clusters at `DevPreviewNoUpgrade`. Not enabled for Hypershift.
2. **Enum constant** — `AdaptableTopologyMode = "Adaptable"` on `TopologyMode`.
3. **Validation markers** — `FeatureGateAwareEnum` annotations on both topology fields that expand the allowed enum values when the gate is enabled. The base (ungated) annotation replaces the previous `kubebuilder:validation:Enum` to avoid overriding feature-gate-aware validation.

Enhancement: https://github.com/openshift/enhancements/pull/1905

🤖 Generated with [Claude Code](https://claude.com/claude-code)