### PR TITLE
OCPBUGS-80958: NodeUID in status to detect replaced node with same name

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -35890,6 +35890,10 @@
           "type": "string",
           "default": ""
         },
+        "nodeUID": {
+          "description": "nodeUID is the UID of the node. This field is used to detect that a node has been deleted and recreated with the same name. When the UID changes, it indicates the node is a new instance and the controller should treat this status entry as stale. When omitted, UID-based node replacement detection is not available for this entry.",
+          "type": "string"
+        },
         "targetRevision": {
           "description": "targetRevision is the generation of the deployment we're trying to apply. Can not be set on creation of a nodeStatus.",
           "type": "integer",

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -266,6 +266,18 @@ type NodeStatus struct {
 	// +required
 	NodeName string `json:"nodeName"`
 
+	// nodeUID is the UID of the node.
+	// This field is used to detect that a node has been deleted and recreated
+	// with the same name. When the UID changes, it indicates the node is a
+	// new instance and the controller should treat this status entry as stale.
+	// When omitted, UID-based node replacement detection is not available
+	// for this entry.
+	// +kubebuilder:validation:MinLength=36
+	// +kubebuilder:validation:MaxLength=36
+	// +kubebuilder:validation:Format=uuid
+	// +optional
+	NodeUID string `json:"nodeUID,omitempty"`
+
 	// currentRevision is the generation of the most recently successful deployment.
 	// Can not be set on creation of a nodeStatus. Updates must only increase the value.
 	// +kubebuilder:validation:XValidation:rule="self >= oldSelf",message="must only increase"

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -279,6 +279,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-OKD.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-OKD.crd.yaml
@@ -279,6 +279,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-CustomNoUpgrade.crd.yaml
@@ -425,6 +425,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-Default.crd.yaml
@@ -276,6 +276,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-DevPreviewNoUpgrade.crd.yaml
@@ -425,6 +425,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-OKD.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-OKD.crd.yaml
@@ -276,6 +276,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers-TechPreviewNoUpgrade.crd.yaml
@@ -425,6 +425,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -270,6 +270,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -261,6 +261,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
@@ -279,6 +279,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -262,6 +262,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/EventTTL.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/EventTTL.yaml
@@ -276,6 +276,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/KMSEncryption.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/KMSEncryption.yaml
@@ -411,6 +411,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -271,6 +271,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
@@ -262,6 +262,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -37,6 +37,7 @@ func (MyOperatorResource) SwaggerDoc() map[string]string {
 var map_NodeStatus = map[string]string{
 	"":                         "NodeStatus provides information about the current state of a particular node managed by this operator.",
 	"nodeName":                 "nodeName is the name of the node",
+	"nodeUID":                  "nodeUID is the UID of the node. This field is used to detect that a node has been deleted and recreated with the same name. When the UID changes, it indicates the node is a new instance and the controller should treat this status entry as stale. When omitted, UID-based node replacement detection is not available for this entry.",
 	"currentRevision":          "currentRevision is the generation of the most recently successful deployment. Can not be set on creation of a nodeStatus. Updates must only increase the value.",
 	"targetRevision":           "targetRevision is the generation of the deployment we're trying to apply. Can not be set on creation of a nodeStatus.",
 	"lastFailedRevision":       "lastFailedRevision is the generation of the deployment we tried and failed to deploy.",

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -279,6 +279,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-OKD.crd.yaml
@@ -279,6 +279,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -292,6 +292,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-CustomNoUpgrade.crd.yaml
@@ -425,6 +425,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-Default.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-Default.crd.yaml
@@ -276,6 +276,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-DevPreviewNoUpgrade.crd.yaml
@@ -425,6 +425,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-OKD.crd.yaml
@@ -276,6 +276,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers-TechPreviewNoUpgrade.crd.yaml
@@ -425,6 +425,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -270,6 +270,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.

--- a/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -261,6 +261,18 @@ spec:
                     nodeName:
                       description: nodeName is the name of the node
                       type: string
+                    nodeUID:
+                      description: |-
+                        nodeUID is the UID of the node.
+                        This field is used to detect that a node has been deleted and recreated
+                        with the same name. When the UID changes, it indicates the node is a
+                        new instance and the controller should treat this status entry as stale.
+                        When omitted, UID-based node replacement detection is not available
+                        for this entry.
+                      format: uuid
+                      maxLength: 36
+                      minLength: 36
+                      type: string
                     targetRevision:
                       description: |-
                         targetRevision is the generation of the deployment we're trying to apply.


### PR DESCRIPTION
Add `NodeUID` to `NodeStatus` in order to handle the case where a node is replaced with the same name. Allows controllers to identify the status as stale and run the appropriate steps to reconcile the new node.

## Related PRs:
https://github.com/openshift/client-go/pull/371
https://github.com/openshift/library-go/pull/2178
https://github.com/openshift/cluster-kube-apiserver-operator/pull/2199