### PR TITLE
Revert "OCPBUGS-83492: Allow :ref suffix in additionalLayerStores path for stargz-store to support lazy image pulling"

### DIFF
--- a/machineconfiguration/v1/tests/containerruntimeconfigs.machineconfiguration.openshift.io/AdditionalStorageConfig.yaml
+++ b/machineconfiguration/v1/tests/containerruntimeconfigs.machineconfiguration.openshift.io/AdditionalStorageConfig.yaml
@@ -26,42 +26,6 @@ tests:
               - path: /mnt/nydus-store
               - path: /opt/layer_store-v1.0
 
-    - name: Should be able to create ContainerRuntimeConfig with additionalLayerStores using :ref suffix for stargz-store
-      initial: |
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: ContainerRuntimeConfig
-        spec:
-          containerRuntimeConfig:
-            additionalLayerStores:
-              - path: /var/lib/stargz-store/store:ref
-      expected: |
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: ContainerRuntimeConfig
-        spec:
-          containerRuntimeConfig:
-            additionalLayerStores:
-              - path: /var/lib/stargz-store/store:ref
-
-    - name: Should be able to create ContainerRuntimeConfig with mixed additionalLayerStores paths (with and without :ref)
-      initial: |
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: ContainerRuntimeConfig
-        spec:
-          containerRuntimeConfig:
-            additionalLayerStores:
-              - path: /var/lib/stargz-store/store:ref
-              - path: /mnt/nydus-store
-              - path: /opt/layer-store:ref
-      expected: |
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: ContainerRuntimeConfig
-        spec:
-          containerRuntimeConfig:
-            additionalLayerStores:
-              - path: /var/lib/stargz-store/store:ref
-              - path: /mnt/nydus-store
-              - path: /opt/layer-store:ref
-
     - name: Should fail if additionalLayerStores path is empty
       initial: |
         apiVersion: machineconfiguration.openshift.io/v1
@@ -80,7 +44,7 @@ tests:
           containerRuntimeConfig:
             additionalLayerStores:
               - path: var/lib/stargz-store
-      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', '-', and optionally end with ':ref'"
+      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', and '-'"
 
     - name: Should fail if additionalLayerStores path contains spaces
       initial: |
@@ -90,7 +54,7 @@ tests:
           containerRuntimeConfig:
             additionalLayerStores:
               - path: /var/lib/stargz store
-      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', '-', and optionally end with ':ref'"
+      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', and '-'"
 
     - name: Should fail if additionalLayerStores path contains invalid characters
       initial: |
@@ -100,17 +64,7 @@ tests:
           containerRuntimeConfig:
             additionalLayerStores:
               - path: /var/lib/stargz@store
-      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', '-', and optionally end with ':ref'"
-
-    - name: Should fail if additionalLayerStores path contains colon with suffix other than :ref
-      initial: |
-        apiVersion: machineconfiguration.openshift.io/v1
-        kind: ContainerRuntimeConfig
-        spec:
-          containerRuntimeConfig:
-            additionalLayerStores:
-              - path: /var/lib/stargz-store:other
-      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', '-', and optionally end with ':ref'"
+      expectedError: "path must be absolute and contain only alphanumeric characters, '/', '.', '_', and '-'"
 
     - name: Should fail if additionalLayerStores path is too long
       initial: |

--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -976,16 +976,6 @@ const (
 // +kubebuilder:validation:XValidation:rule="!self.contains('//')",message="path must not contain consecutive forward slashes"
 type StorePath string
 
-// LayerStorePath is an absolute filesystem path used by additional layer store configurations.
-// The path must be between 1 and 256 characters long, begin with a forward slash, and only contain
-// the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix for reference-based layer organization (e.g., stargz-store).
-// Consecutive forward slashes are not permitted.
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=256
-// +kubebuilder:validation:XValidation:rule="self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')",message="path must be absolute and contain only alphanumeric characters, '/', '.', '_', '-', and optionally end with ':ref'"
-// +kubebuilder:validation:XValidation:rule="!self.contains('//')",message="path must not contain consecutive forward slashes"
-type LayerStorePath string
-
 // AdditionalLayerStore defines a read-only storage location for Open Container Initiative (OCI) container image layers.
 type AdditionalLayerStore struct {
 	// path specifies the absolute location of the additional layer store.
@@ -993,11 +983,10 @@ type AdditionalLayerStore struct {
 	// When a container image is requested, layers found at this location will be used instead of
 	// retrieving from the registry.
 	// The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-	// and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-	// for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+	// and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
 	// Consecutive forward slashes are not permitted.
 	// +required
-	Path LayerStorePath `json:"path,omitempty"`
+	Path StorePath `json:"path,omitempty"`
 }
 
 // AdditionalImageStore defines an additional read-only storage location for Open Container Initiative (OCI) images.

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs-CustomNoUpgrade.crd.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/containerruntimeconfigs.machineconfiguration.openshift.io/AdditionalStorageConfig.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/containerruntimeconfigs.machineconfiguration.openshift.io/AdditionalStorageConfig.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:

--- a/machineconfiguration/v1/zz_generated.swagger_doc_generated.go
+++ b/machineconfiguration/v1/zz_generated.swagger_doc_generated.go
@@ -31,7 +31,7 @@ func (AdditionalImageStore) SwaggerDoc() map[string]string {
 
 var map_AdditionalLayerStore = map[string]string{
 	"":     "AdditionalLayerStore defines a read-only storage location for Open Container Initiative (OCI) container image layers.",
-	"path": "path specifies the absolute location of the additional layer store. The path must exist on the node before configuration is applied. When a container image is requested, layers found at this location will be used instead of retrieving from the registry. The path is required and must be between 1 and 256 characters long, begin with a forward slash, and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store). Consecutive forward slashes are not permitted.",
+	"path": "path specifies the absolute location of the additional layer store. The path must exist on the node before configuration is applied. When a container image is requested, layers found at this location will be used instead of retrieving from the registry. The path is required and must be between 1 and 256 characters long, begin with a forward slash, and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'. Consecutive forward slashes are not permitted.",
 }
 
 func (AdditionalLayerStore) SwaggerDoc() map[string]string {

--- a/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs-CustomNoUpgrade.crd.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:

--- a/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:

--- a/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -163,17 +163,15 @@ spec:
                             When a container image is requested, layers found at this location will be used instead of
                             retrieving from the registry.
                             The path is required and must be between 1 and 256 characters long, begin with a forward slash,
-                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', '-', and may end with the ':ref' suffix
-                            for reference-based layer organization (e.g., /var/lib/stargz-store/store:ref for stargz-store).
+                            and only contain the characters a-z, A-Z, 0-9, '/', '.', '_', and '-'.
                             Consecutive forward slashes are not permitted.
                           maxLength: 256
                           minLength: 1
                           type: string
                           x-kubernetes-validations:
                           - message: path must be absolute and contain only alphanumeric
-                              characters, '/', '.', '_', '-', and optionally end with
-                              ':ref'
-                            rule: self.matches('^/[a-zA-Z0-9/._-]+(:ref)?$')
+                              characters, '/', '.', '_', and '-'
+                            rule: self.matches('^/[a-zA-Z0-9/._-]+$')
                           - message: path must not contain consecutive forward slashes
                             rule: '!self.contains(''//'')'
                       required:


### PR DESCRIPTION
This reverts commit 47e56c70d96fae5e7f352f89e658403691c33727 (PR #2806)
Reason for Revert:
The `:ref` suffix should **not** be exposed in the user-facing API. Instead, the Machine Config Operator (MCO) should handle this implementation detail automatically.

Correct Approach:
The `:ref` suffix is an implementation detail of how stargz-store integrates with CRI-O's `additionalLayerStores`. This should be handled automatically by the MCO during the translation phase from ContainerRuntimeConfig CR to the node's `storage.conf` file

 Related
 - Original PR: #2806
 - Related Bug: OCPBUGS-83492
 - MCO should handle this in: https://github.com/openshift/machine-config-operator/pull/5888 
