### PR TITLE
OPRUN-4590: Add OLMLifecycleAndCompatibility feature gate

### DIFF
--- a/features.md
+++ b/features.md
@@ -22,6 +22,7 @@
 | NewOLMOwnSingleNamespace| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMPreflightPermissionChecks| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NoRegistryClusterInstall| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
+| OLMLifecycleAndCompatibility| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | ProvisioningRequestAvailable| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | VSphereMultiVCenterDay2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -472,6 +472,14 @@ var (
 					enable(inClusterProfile(SelfManaged), inDevPreviewNoUpgrade(), inTechPreviewNoUpgrade()).
 					mustRegister()
 
+	FeatureGateOLMLifecycleAndCompatibility = newFeatureGate("OLMLifecycleAndCompatibility").
+								reportProblemsToJiraComponent("olm").
+								contactPerson("joelanford").
+								productScope(ocpSpecific).
+								enhancementPR("https://github.com/openshift/enhancements/pull/1991").
+								enable(inClusterProfile(SelfManaged), inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
+								mustRegister()
+
 	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").
 						reportProblemsToJiraComponent("insights").
 						contactPerson("tremes").

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
@@ -243,6 +243,9 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "OSStreams"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
@@ -56,6 +56,9 @@
                         "name": "NoRegistryClusterInstall"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "ShortCertRotation"
                     }
                 ],

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
@@ -245,6 +245,9 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "OSStreams"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
@@ -86,6 +86,9 @@
                         "name": "NoRegistryClusterInstall"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "ProvisioningRequestAvailable"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
@@ -237,6 +237,9 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "OSStreams"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -304,6 +304,9 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "OSStreams"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
@@ -239,6 +239,9 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "OSStreams"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -310,6 +310,9 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
+                        "name": "OLMLifecycleAndCompatibility"
+                    },
+                    {
                         "name": "OSStreams"
                     },
                     {


### PR DESCRIPTION
## Summary
- Adds a new `OLMLifecycleAndCompatibility` feature gate for OLM lifecycle and compatibility metadata support
- Enabled in `TechPreviewNoUpgrade` and `DevPreviewNoUpgrade` feature sets for the `SelfManaged` cluster profile
- Regenerated payload feature gate manifests via `make update-payload-featuregates`

Enhancement: https://github.com/openshift/enhancements/pull/1991

## Test plan
- [ ] `make verify-payload-featuregates` passes
- [ ] `make verify` passes
- [ ] Gate appears as enabled in TechPreview/DevPreview SelfManaged manifests
- [ ] Gate appears as disabled in Default/OKD manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)