### PR TITLE
CNTRLPLANE-3361: make transitMount required

### DIFF
--- a/config/v1/tests/apiservers.config.openshift.io/KMSEncryption.yaml
+++ b/config/v1/tests/apiservers.config.openshift.io/KMSEncryption.yaml
@@ -76,5 +76,6 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "kms config is required when encryption type is KMS, and forbidden otherwise"

--- a/config/v1/tests/apiservers.config.openshift.io/VaultKMS.yaml
+++ b/config/v1/tests/apiservers.config.openshift.io/VaultKMS.yaml
@@ -23,6 +23,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
       expected: |
         apiVersion: config.openshift.io/v1
@@ -42,6 +43,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
 
     - name: Should accept kmsPluginImage with simple two-level path like quay.io/vault/kms-plugin
@@ -61,6 +63,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
       expected: |
         apiVersion: config.openshift.io/v1
@@ -80,6 +83,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
 
     - name: Should be able to create with full Vault KMS Plugin config including all optional fields
@@ -150,6 +154,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
       expected: |
         apiVersion: config.openshift.io/v1
@@ -169,6 +174,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
 
     - name: Should accept kmsPluginImage with deep multi-level namespace path
@@ -188,6 +194,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
       expected: |
         apiVersion: config.openshift.io/v1
@@ -207,6 +214,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-encryption-key
 
     # RFC 3986 unreserved character tests
@@ -307,6 +315,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: encryption.key.v1
       expected: |
         apiVersion: config.openshift.io/v1
@@ -326,6 +335,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: encryption.key.v1
 
     - name: Should reject transitKey with tilde character
@@ -345,6 +355,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: key~backup
       expectedError: "transitKey must only contain alphanumeric characters, hyphens, periods, and underscores"
 
@@ -375,8 +386,30 @@ tests:
                 vaultAddress: https://vault.example.com:8200
                 authentication:
                   type: AppRole
+                transitMount: transit
                 transitKey: my-key
       expectedError: "appRole config is required when authentication type is AppRole"
+
+    # transitMount required field validation
+    - name: Should reject Vault KMS config without transitMount
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          encryption:
+            type: KMS
+            kms:
+              type: Vault
+              vault:
+                kmsPluginImage: registry.example.com/vault-plugin@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+                vaultAddress: https://vault.example.com:8200
+                authentication:
+                  type: AppRole
+                  appRole:
+                    secret:
+                      name: vault-approle
+                transitKey: my-key
+      expectedError: "Required value"
 
     # kmsPluginImage validation tests
     - name: Should reject kmsPluginImage with tag instead of digest
@@ -396,6 +429,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "the OCI Image reference must end with a valid '@sha256:<digest>' suffix"
 
@@ -416,6 +450,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "the OCI Image name should follow the host[:port][/namespace]/name format"
 
@@ -436,6 +471,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "the OCI Image reference must end with a valid '@sha256:<digest>' suffix, where '<digest>' is 64 characters long"
 
@@ -457,6 +493,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "must use the 'https' scheme"
 
@@ -477,6 +514,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "must not contain a path"
 
@@ -497,6 +535,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "must not have a query"
 
@@ -517,6 +556,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "must not have a fragment"
 
@@ -537,6 +577,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "must not have user info"
 
@@ -559,6 +600,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot end with a forward slash"
 
@@ -580,6 +622,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot contain spaces"
 
@@ -601,6 +644,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot be a reserved string"
 
@@ -622,6 +666,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot be a reserved string"
 
@@ -643,6 +688,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot be a reserved string"
 
@@ -664,6 +710,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot be a reserved string"
 
@@ -685,6 +732,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot be a reserved string"
 
@@ -706,6 +754,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "vaultNamespace cannot be a reserved string"
 
@@ -812,6 +861,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my encryption key
       expectedError: "transitKey must only contain alphanumeric characters, hyphens, periods, and underscores"
 
@@ -832,6 +882,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my/key
       expectedError: "transitKey cannot contain forward slashes"
 
@@ -873,6 +924,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my@key
       expectedError: "transitKey must only contain alphanumeric characters, hyphens, periods, and underscores"
 
@@ -896,6 +948,7 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "serverName must be a valid DNS hostname"
 
@@ -917,6 +970,7 @@ tests:
                   appRole:
                     secret:
                       name: invalid_secret_name!
+                transitMount: transit
                 transitKey: my-key
       expectedError: "name must be a valid DNS subdomain name"
 
@@ -940,5 +994,6 @@ tests:
                   appRole:
                     secret:
                       name: vault-approle
+                transitMount: transit
                 transitKey: my-key
       expectedError: "name must be a valid DNS subdomain name"

--- a/config/v1/types_kmsencryption.go
+++ b/config/v1/types_kmsencryption.go
@@ -193,14 +193,10 @@ type VaultKMSPluginConfig struct {
 
 	// transitMount specifies the mount path of the Vault Transit engine.
 	//
-	// When omitted, this means the user has no opinion and the platform is left
-	// to choose a reasonable default. These defaults are subject to change over time.
-	// The current default is "transit".
-	//
-	// The transit mount must be between 1 and 1024 characters when specified, cannot start or
-	// end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-	// RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-	// slashes as path separators.
+	// The transit mount must be between 1 and 1024 characters, cannot start or
+	// end with a forward slash, cannot contain consecutive forward slashes, and
+	// must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+	// period, underscore, tilde) and forward slashes as path separators.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=1024
@@ -208,7 +204,7 @@ type VaultKMSPluginConfig struct {
 	// +kubebuilder:validation:XValidation:rule="!self.endsWith('/')",message="transitMount cannot end with a forward slash"
 	// +kubebuilder:validation:XValidation:rule="!self.contains('//')",message="transitMount cannot contain consecutive forward slashes"
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-zA-Z0-9._~/-]+$')",message="transitMount must only contain RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward slashes"
-	// +optional
+	// +required
 	TransitMount string `json:"transitMount,omitempty"`
 
 	// transitKey specifies the name of the encryption key in Vault's Transit engine.

--- a/config/v1/types_kmsencryption.go
+++ b/config/v1/types_kmsencryption.go
@@ -114,7 +114,7 @@ const (
 type VaultAppRoleAuthentication struct {
 	// secret references a secret in the openshift-config namespace containing
 	// the AppRole credentials used to authenticate with Vault.
-	// The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+	// The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
 	//
 	// +required
 	Secret VaultSecretReference `json:"secret,omitzero"`
@@ -230,7 +230,7 @@ type VaultKMSPluginConfig struct {
 type VaultTLSConfig struct {
 	// caBundle references a ConfigMap in the openshift-config namespace containing
 	// the CA certificate bundle used to verify the TLS connection to the Vault server.
-	// The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+	// The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
 	// When this field is not set, the system's trusted CA certificates are used.
 	//
 	// The namespace for the ConfigMap is openshift-config.

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:

--- a/config/v1/zz_generated.featuregated-crd-manifests/apiservers.config.openshift.io/KMSEncryption.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/apiservers.config.openshift.io/KMSEncryption.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -2341,7 +2341,7 @@ func (KMSPluginConfig) SwaggerDoc() map[string]string {
 
 var map_VaultAppRoleAuthentication = map[string]string{
 	"":       "VaultAppRoleAuthentication defines the configuration for AppRole authentication with Vault.",
-	"secret": "secret references a secret in the openshift-config namespace containing the AppRole credentials used to authenticate with Vault. The secret must contain two keys: \"role-id\" for the AppRole Role ID and \"secret-id\" for the AppRole Secret ID.",
+	"secret": "secret references a secret in the openshift-config namespace containing the AppRole credentials used to authenticate with Vault. The referenced Secret must contain two keys: \"role-id\" for the AppRole Role ID and \"secret-id\" for the AppRole Secret ID.",
 }
 
 func (VaultAppRoleAuthentication) SwaggerDoc() map[string]string {
@@ -2374,7 +2374,7 @@ var map_VaultKMSPluginConfig = map[string]string{
 	"vaultNamespace": "vaultNamespace specifies the Vault namespace where the Transit secrets engine is mounted. This is only applicable for Vault Enterprise installations. When this field is not set, no namespace is used.\n\nThe value must be between 1 and 4096 characters. The namespace cannot end with a forward slash, cannot contain spaces, and cannot be one of the reserved strings: root, sys, audit, auth, cubbyhole, or identity.",
 	"tls":            "tls contains the TLS configuration for connecting to the Vault server. When this field is not set, system default TLS settings are used.",
 	"authentication": "authentication defines the authentication method used to authenticate with Vault.",
-	"transitMount":   "transitMount specifies the mount path of the Vault Transit engine.\n\nWhen omitted, this means the user has no opinion and the platform is left to choose a reasonable default. These defaults are subject to change over time. The current default is \"transit\".\n\nThe transit mount must be between 1 and 1024 characters when specified, cannot start or end with a forward slash, cannot contain consecutive forward slashes, and must only contain RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward slashes as path separators.",
+	"transitMount":   "transitMount specifies the mount path of the Vault Transit engine.\n\nThe transit mount must be between 1 and 1024 characters, cannot start or end with a forward slash, cannot contain consecutive forward slashes, and must only contain RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward slashes as path separators.",
 	"transitKey":     "transitKey specifies the name of the encryption key in Vault's Transit engine. This key is used to encrypt and decrypt data.\n\nThe transit key must be between 1 and 512 characters, cannot contain forward slashes, and must only contain alphanumeric characters, hyphens, periods, and underscores.",
 }
 
@@ -2393,7 +2393,7 @@ func (VaultSecretReference) SwaggerDoc() map[string]string {
 
 var map_VaultTLSConfig = map[string]string{
 	"":           "VaultTLSConfig contains TLS configuration for connecting to Vault.",
-	"caBundle":   "caBundle references a ConfigMap in the openshift-config namespace containing the CA certificate bundle used to verify the TLS connection to the Vault server. The ConfigMap must contain the CA bundle in the key \"ca-bundle.crt\". When this field is not set, the system's trusted CA certificates are used.\n\nThe namespace for the ConfigMap is openshift-config.\n\nExample ConfigMap:\n  apiVersion: v1\n  kind: ConfigMap\n  metadata:\n    name: vault-ca-bundle\n    namespace: openshift-config\n  data:\n    ca-bundle.crt: |",
+	"caBundle":   "caBundle references a ConfigMap in the openshift-config namespace containing the CA certificate bundle used to verify the TLS connection to the Vault server. The referenced ConfigMap must contain the CA bundle in the key \"ca-bundle.crt\". When this field is not set, the system's trusted CA certificates are used.\n\nThe namespace for the ConfigMap is openshift-config.\n\nExample ConfigMap:\n  apiVersion: v1\n  kind: ConfigMap\n  metadata:\n    name: vault-ca-bundle\n    namespace: openshift-config\n  data:\n    ca-bundle.crt: |",
 	"serverName": "serverName specifies the Server Name Indication (SNI) to use when connecting to Vault via TLS. This is useful when the Vault server's hostname doesn't match its TLS certificate. When this field is not set, the hostname from vaultAddress is used for SNI.\n\nThe value must be a valid DNS hostname: it must contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character.",
 }
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -15834,6 +15834,7 @@
       "properties": {
         "kms": {
           "description": "kms defines the configuration for the external KMS instance that manages the encryption keys, when KMS encryption is enabled sensitive resources will be encrypted using keys managed by an externally configured KMS instance.\n\nThe Key Management Service (KMS) instance provides symmetric encryption and is responsible for managing the lifecyle of the encryption keys outside of the control plane. This allows integration with an external provider to manage the data encryption keys securely.",
+          "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.KMSPluginConfig"
         },
         "type": {
@@ -22323,7 +22324,7 @@
       "type": "object",
       "properties": {
         "allowedRegistries": {
-          "description": "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+          "description": "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied. Each entry must be a valid registry scope in the format hostname[:port][/path], optionally prefixed with \"*.\" for wildcard subdomains (e.g., \"*.example.com\"). The hostname must consist of valid DNS labels separated by dots, where each label contains only alphanumeric characters and hyphens and does not start or end with a hyphen. Entries must not be empty, must not include tags (e.g., \":latest\") or digests (e.g., \"@sha256:...\"), and must be at most 256 characters in length. The list may contain at most 1024 entries.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
           "type": "array",
           "items": {
             "type": "string",
@@ -22332,7 +22333,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "blockedRegistries": {
-          "description": "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+          "description": "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted. Each entry must be a valid registry scope in the format hostname[:port][/path], optionally prefixed with \"*.\" for wildcard subdomains (e.g., \"*.example.com\"). The hostname must consist of valid DNS labels separated by dots, where each label contains only alphanumeric characters and hyphens and does not start or end with a hyphen. Entries must not be empty, must not include tags (e.g., \":latest\") or digests (e.g., \"@sha256:...\"), and must be at most 256 characters in length. The list may contain at most 1024 entries.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
           "type": "array",
           "items": {
             "type": "string",
@@ -22350,7 +22351,7 @@
           "x-kubernetes-list-type": "set"
         },
         "insecureRegistries": {
-          "description": "insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.",
+          "description": "insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections. Each entry must be a valid registry scope in the format hostname[:port][/path], optionally prefixed with \"*.\" for wildcard subdomains (e.g., \"*.example.com\"). The hostname must consist of valid DNS labels separated by dots, where each label contains only alphanumeric characters and hyphens and does not start or end with a hyphen. Entries must not be empty, must not include tags (e.g., \":latest\") or digests (e.g., \"@sha256:...\"), and must be at most 256 characters in length. The list may contain at most 1024 entries.",
           "type": "array",
           "items": {
             "type": "string",
@@ -23703,7 +23704,7 @@
       ],
       "properties": {
         "secret": {
-          "description": "secret references a secret in the openshift-config namespace containing the AppRole credentials used to authenticate with Vault. The secret must contain two keys: \"role-id\" for the AppRole Role ID and \"secret-id\" for the AppRole Secret ID.",
+          "description": "secret references a secret in the openshift-config namespace containing the AppRole credentials used to authenticate with Vault. The referenced Secret must contain two keys: \"role-id\" for the AppRole Role ID and \"secret-id\" for the AppRole Secret ID.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.VaultSecretReference"
         }
@@ -23755,6 +23756,7 @@
         "kmsPluginImage",
         "vaultAddress",
         "authentication",
+        "transitMount",
         "transitKey"
       ],
       "properties": {
@@ -23777,7 +23779,7 @@
           "type": "string"
         },
         "transitMount": {
-          "description": "transitMount specifies the mount path of the Vault Transit engine.\n\nWhen omitted, this means the user has no opinion and the platform is left to choose a reasonable default. These defaults are subject to change over time. The current default is \"transit\".\n\nThe transit mount must be between 1 and 1024 characters when specified, cannot start or end with a forward slash, cannot contain consecutive forward slashes, and must only contain RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward slashes as path separators.",
+          "description": "transitMount specifies the mount path of the Vault Transit engine.\n\nThe transit mount must be between 1 and 1024 characters, cannot start or end with a forward slash, cannot contain consecutive forward slashes, and must only contain RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward slashes as path separators.",
           "type": "string"
         },
         "vaultAddress": {
@@ -23808,7 +23810,7 @@
       "type": "object",
       "properties": {
         "caBundle": {
-          "description": "caBundle references a ConfigMap in the openshift-config namespace containing the CA certificate bundle used to verify the TLS connection to the Vault server. The ConfigMap must contain the CA bundle in the key \"ca-bundle.crt\". When this field is not set, the system's trusted CA certificates are used.\n\nThe namespace for the ConfigMap is openshift-config.\n\nExample ConfigMap:\n  apiVersion: v1\n  kind: ConfigMap\n  metadata:\n    name: vault-ca-bundle\n    namespace: openshift-config\n  data:\n    ca-bundle.crt: |\n      -----BEGIN CERTIFICATE-----\n      ...\n      -----END CERTIFICATE-----",
+          "description": "caBundle references a ConfigMap in the openshift-config namespace containing the CA certificate bundle used to verify the TLS connection to the Vault server. The referenced ConfigMap must contain the CA bundle in the key \"ca-bundle.crt\". When this field is not set, the system's trusted CA certificates are used.\n\nThe namespace for the ConfigMap is openshift-config.\n\nExample ConfigMap:\n  apiVersion: v1\n  kind: ConfigMap\n  metadata:\n    name: vault-ca-bundle\n    namespace: openshift-config\n  data:\n    ca-bundle.crt: |\n      -----BEGIN CERTIFICATE-----\n      ...\n      -----END CERTIFICATE-----",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.VaultConfigMapReference"
         },
@@ -24844,6 +24846,11 @@
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1alpha1.NodeExporterCollectorProcessesConfig"
         },
+        "softirqs": {
+          "description": "softirqs configures the softirqs collector, which exposes detailed softirq statistics from /proc/softirqs. softirqs is optional. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is disabled. Enable when you need visibility into kernel softirq processing across CPUs.",
+          "default": {},
+          "$ref": "#/definitions/com.github.openshift.api.config.v1alpha1.NodeExporterCollectorSoftirqsConfig"
+        },
         "systemd": {
           "description": "systemd configures the systemd collector, which collects statistics on the systemd daemon and its managed services. systemd is optional. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is disabled. Enabling this collector with a long list of selected units may produce metrics with high cardinality. If you enable this collector, closely monitor the prometheus-k8s deployment for excessive memory usage. Enable when you need metrics for specific units; scope units carefully.",
           "default": {},
@@ -24994,6 +25001,23 @@
       "properties": {
         "collectionPolicy": {
           "description": "collectionPolicy declares whether the processes collector collects metrics. This field is required. Valid values are \"Collect\" and \"DoNotCollect\". When set to \"Collect\", the processes collector is active and process/thread statistics are collected. When set to \"DoNotCollect\", the processes collector is inactive.\n\nPossible enum values:\n - `\"Collect\"` means the collector is active and will produce metrics.\n - `\"DoNotCollect\"` means the collector is inactive and will not produce metrics.",
+          "type": "string",
+          "enum": [
+            "Collect",
+            "DoNotCollect"
+          ]
+        }
+      }
+    },
+    "com.github.openshift.api.config.v1alpha1.NodeExporterCollectorSoftirqsConfig": {
+      "description": "NodeExporterCollectorSoftirqsConfig provides configuration for the softirqs collector of the node-exporter agent. The softirqs collector exposes detailed softirq statistics from /proc/softirqs. It is disabled by default.",
+      "type": "object",
+      "required": [
+        "collectionPolicy"
+      ],
+      "properties": {
+        "collectionPolicy": {
+          "description": "collectionPolicy declares whether the softirqs collector collects metrics. This field is required. Valid values are \"Collect\" and \"DoNotCollect\". When set to \"Collect\", the softirqs collector is active and softirq statistics are collected. When set to \"DoNotCollect\", the softirqs collector is inactive.\n\nPossible enum values:\n - `\"Collect\"` means the collector is active and will produce metrics.\n - `\"DoNotCollect\"` means the collector is inactive and will not produce metrics.",
           "type": "string",
           "enum": [
             "Collect",

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
@@ -196,7 +196,7 @@ spec:
                                     description: |-
                                       secret references a secret in the openshift-config namespace containing
                                       the AppRole credentials used to authenticate with Vault.
-                                      The secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
+                                      The referenced Secret must contain two keys: "role-id" for the AppRole Role ID and "secret-id" for the AppRole Secret ID.
                                     properties:
                                       name:
                                         description: |-
@@ -276,7 +276,7 @@ spec:
                                 description: |-
                                   caBundle references a ConfigMap in the openshift-config namespace containing
                                   the CA certificate bundle used to verify the TLS connection to the Vault server.
-                                  The ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
+                                  The referenced ConfigMap must contain the CA bundle in the key "ca-bundle.crt".
                                   When this field is not set, the system's trusted CA certificates are used.
 
                                   The namespace for the ConfigMap is openshift-config.
@@ -349,14 +349,10 @@ spec:
                             description: |-
                               transitMount specifies the mount path of the Vault Transit engine.
 
-                              When omitted, this means the user has no opinion and the platform is left
-                              to choose a reasonable default. These defaults are subject to change over time.
-                              The current default is "transit".
-
-                              The transit mount must be between 1 and 1024 characters when specified, cannot start or
-                              end with a forward slash, cannot contain consecutive forward slashes, and must only contain
-                              RFC 3986 unreserved characters (alphanumeric, hyphen, period, underscore, tilde) and forward
-                              slashes as path separators.
+                              The transit mount must be between 1 and 1024 characters, cannot start or
+                              end with a forward slash, cannot contain consecutive forward slashes, and
+                              must only contain RFC 3986 unreserved characters (alphanumeric, hyphen,
+                              period, underscore, tilde) and forward slashes as path separators.
                             maxLength: 1024
                             minLength: 1
                             type: string
@@ -423,6 +419,7 @@ spec:
                         - authentication
                         - kmsPluginImage
                         - transitKey
+                        - transitMount
                         - vaultAddress
                         type: object
                     required:


### PR DESCRIPTION
also update the tests, and rephrase secret and configmap reference godocs.

background: the vault team is going to make this field required in their plugin (while also removing the default).