### PR TITLE
Add KubeletConfigAccepted const in 'machineconfiguration/v1/types.go'

### DIFF
--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -811,10 +811,17 @@ type KubeletConfigCondition struct {
 type KubeletConfigStatusConditionType string
 
 const (
+	// KubeletConfigAccepted designates whether a KubeletConfig CR has been accepted.
+	// When the condition status is True, the KubeletConfig has been accepted successfully.
+	// When the condition status is False, the KubeletConfig has not been accepted.
+	KubeletConfigAccepted KubeletConfigStatusConditionType = "Accepted"
+
 	// KubeletConfigSuccess designates a successful application of a KubeletConfig CR.
+	// Deprecated: Use KubeletConfigAccepted instead. KubeletConfigSuccess will be removed in a future release.
 	KubeletConfigSuccess KubeletConfigStatusConditionType = "Success"
 
 	// KubeletConfigFailure designates a failure applying a KubeletConfig CR.
+	// Deprecated: Use KubeletConfigAccepted with status False instead. KubeletConfigFailure will be removed in a future release.
 	KubeletConfigFailure KubeletConfigStatusConditionType = "Failure"
 )
 


### PR DESCRIPTION
Add a new `KubeletConfigAccepted` constant of type `KubeletConfigStatusConditionType` to replace the separate `KubeletConfigSuccess` and `KubeletConfigFailure` condition types with a single unified condition type.

KubeletConfig currently uses two separate condition types — Success and Failure — to report status. This deviates from Kubernetes conventions:
  - Standard practice uses a single condition type with Status: True/False to indicate outcome
  - Two separate types make it harder to query condition state — consumers must check both Success and Failure instead of reading one condition
  - On success, Status.Conditions.Type and Status.Conditions.Message both show "Success", which is redundant and less informative 

~~~
status:
  Conditions:
    Message:               Success
    Status:                True
    Type:                  Success
~~~
  
   ## Changes

   - Added `KubeletConfigAccepted KubeletConfigStatusConditionType = "Accepted"` constant.
    - Status: True, Type: Accepted — the KubeletConfig CR has been accepted successfully
    - Status: False, Type: Accepted  — the KubeletConfig CR was rejected (reason in Message field)

   - Marked `KubeletConfigSuccess` and `KubeletConfigFailure` as deprecated with guidance to use `KubeletConfigAccepted` instead

   ## Related

   - Consumer PR: [openshift/machine-config-operator#5854](https://github.com/openshift/machine-config-operator/pull/5854) — updates the MCO to use the new `KubeletConfigAccepted` condition type
   - Jira: [OCPNODE-4040](https://redhat.atlassian.net/browse/OCPNODE-4040)

