### PR TITLE
operator/v1: replace anyOf with CEL XValidation for maxConnections

### DIFF
--- a/operator/v1/manual-override-crd-manifests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/manual-override-crd-manifests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -26,18 +26,6 @@ spec:
                             - properties:
                                 address:
                                   format: ipv6
-              tuningOptions:
-                anyOf:
-                - properties:
-                    maxConnections:
-                      enum:
-                      - -1
-                      - 0
-                - properties:
-                    maxConnections:
-                      format: int32
-                      maximum: 2000000
-                      minimum: 2000
     subresources:
       scale:
         labelSelectorPath: .status.selector

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -678,6 +678,138 @@ tests:
           tuningOptions:
             httpKeepAliveTimeout: 0.001ms
       expectedError: "IngressController.operator.openshift.io \"default\" is invalid: spec.tuningOptions.httpKeepAliveTimeout: Invalid value: \"string\": httpKeepAliveTimeout must be greater than or equal to 1 millisecond"
+    - name: Should be able to create an IngressController with maxConnections set to -1
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: -1
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          idleConnectionTerminationPolicy: Immediate
+          closedClientConnectionPolicy: Continue
+          tuningOptions:
+            maxConnections: -1
+    - name: Should be able to create an IngressController with maxConnections at minimum range
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 2000
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          idleConnectionTerminationPolicy: Immediate
+          closedClientConnectionPolicy: Continue
+          tuningOptions:
+            maxConnections: 2000
+    - name: Should be able to create an IngressController with maxConnections at maximum range
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 2000000
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          idleConnectionTerminationPolicy: Immediate
+          closedClientConnectionPolicy: Continue
+          tuningOptions:
+            maxConnections: 2000000
+    - name: Should be able to create an IngressController with maxConnections in mid range
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 50000
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          idleConnectionTerminationPolicy: Immediate
+          closedClientConnectionPolicy: Continue
+          tuningOptions:
+            maxConnections: 50000
+    - name: Should not be able to create an IngressController with maxConnections below minimum range
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 500
+      expectedError: "maxConnections must be 0, -1, or between 2000 and 2000000"
+    - name: Should not be able to create an IngressController with maxConnections above maximum range
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 3000000
+      expectedError: "maxConnections must be 0, -1, or between 2000 and 2000000"
+    - name: Should not be able to create an IngressController with maxConnections of 1
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 1
+      expectedError: "maxConnections must be 0, -1, or between 2000 and 2000000"
+    - name: Should not be able to create an IngressController with maxConnections of 1999
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 1999
+      expectedError: "maxConnections must be 0, -1, or between 2000 and 2000000"
     - name: Should be able to create an IngressController with valid domain
       initial: |
         apiVersion: operator.openshift.io/v1
@@ -829,4 +961,97 @@ tests:
           idleConnectionTerminationPolicy: Immediate
           closedClientConnectionPolicy: Continue
           domain: "*.foo.com"
+          replicas: 3
+    - name: Should be able to update invalid maxConnections to a valid value
+      initialCRDPatches:
+        - op: remove
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/tuningOptions/properties/maxConnections/x-kubernetes-validations
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 500
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 50000
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          idleConnectionTerminationPolicy: Immediate
+          closedClientConnectionPolicy: Continue
+          tuningOptions:
+            maxConnections: 50000
+    - name: Should not be able to update invalid maxConnections to another invalid value
+      initialCRDPatches:
+        - op: remove
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/tuningOptions/properties/maxConnections/x-kubernetes-validations
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 500
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 999
+      expectedError: "maxConnections must be 0, -1, or between 2000 and 2000000"
+    - name: Should be able to update other fields while retaining invalid maxConnections due to ratcheting
+      initialCRDPatches:
+        - op: remove
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/tuningOptions/properties/maxConnections/x-kubernetes-validations
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 500
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          tuningOptions:
+            maxConnections: 500
+          replicas: 3
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: ic-maxconn-test
+          namespace: openshift-ingress-operator
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          idleConnectionTerminationPolicy: Immediate
+          closedClientConnectionPolicy: Continue
+          tuningOptions:
+            maxConnections: 500
           replicas: 3

--- a/operator/v1/types_ingresscontroller.go
+++ b/operator/v1/types_ingresscontroller.go
@@ -2034,6 +2034,7 @@ type IngressControllerTuningOptions struct {
 	// processes in router containers with the following metric:
 	// 'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
 	//
+	// +kubebuilder:validation:XValidation:rule="self == 0 || self == -1 || (self >= 2000 && self <= 2000000)",message="maxConnections must be 0, -1, or between 2000 and 2000000"
 	// +optional
 	MaxConnections int32 `json:"maxConnections,omitempty"`
 

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-CustomNoUpgrade.crd.yaml
@@ -2180,17 +2180,6 @@ spec:
                     type: string
                 type: object
               tuningOptions:
-                anyOf:
-                - properties:
-                    maxConnections:
-                      enum:
-                      - -1
-                      - 0
-                - properties:
-                    maxConnections:
-                      format: int32
-                      maximum: 2000000
-                      minimum: 2000
                 description: |-
                   tuningOptions defines parameters for adjusting the performance of
                   ingress controller pods. All fields are optional and will use their
@@ -2403,6 +2392,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-Default.crd.yaml
@@ -2140,17 +2140,6 @@ spec:
                     type: string
                 type: object
               tuningOptions:
-                anyOf:
-                - properties:
-                    maxConnections:
-                      enum:
-                      - -1
-                      - 0
-                - properties:
-                    maxConnections:
-                      format: int32
-                      maximum: 2000000
-                      minimum: 2000
                 description: |-
                   tuningOptions defines parameters for adjusting the performance of
                   ingress controller pods. All fields are optional and will use their
@@ -2332,6 +2321,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-DevPreviewNoUpgrade.crd.yaml
@@ -2180,17 +2180,6 @@ spec:
                     type: string
                 type: object
               tuningOptions:
-                anyOf:
-                - properties:
-                    maxConnections:
-                      enum:
-                      - -1
-                      - 0
-                - properties:
-                    maxConnections:
-                      format: int32
-                      maximum: 2000000
-                      minimum: 2000
                 description: |-
                   tuningOptions defines parameters for adjusting the performance of
                   ingress controller pods. All fields are optional and will use their
@@ -2403,6 +2392,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-OKD.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-OKD.crd.yaml
@@ -2140,17 +2140,6 @@ spec:
                     type: string
                 type: object
               tuningOptions:
-                anyOf:
-                - properties:
-                    maxConnections:
-                      enum:
-                      - -1
-                      - 0
-                - properties:
-                    maxConnections:
-                      format: int32
-                      maximum: 2000000
-                      minimum: 2000
                 description: |-
                   tuningOptions defines parameters for adjusting the performance of
                   ingress controller pods. All fields are optional and will use their
@@ -2332,6 +2321,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-TechPreviewNoUpgrade.crd.yaml
@@ -2180,17 +2180,6 @@ spec:
                     type: string
                 type: object
               tuningOptions:
-                anyOf:
-                - properties:
-                    maxConnections:
-                      enum:
-                      - -1
-                      - 0
-                - properties:
-                    maxConnections:
-                      format: int32
-                      maximum: 2000000
-                      minimum: 2000
                 description: |-
                   tuningOptions defines parameters for adjusting the performance of
                   ingress controller pods. All fields are optional and will use their
@@ -2403,6 +2392,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -2314,6 +2314,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/IngressControllerDynamicConfigurationManager.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/IngressControllerDynamicConfigurationManager.yaml
@@ -2345,6 +2345,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/TLSGroupPreferences.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/TLSGroupPreferences.yaml
@@ -2354,6 +2354,9 @@ spec:
                       'container_memory_working_set_bytes{container="router",namespace="openshift-ingress"}/container_processes{container="router",namespace="openshift-ingress"}'.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maxConnections must be 0, -1, or between 2000 and 2000000
+                      rule: self == 0 || self == -1 || (self >= 2000 && self <= 2000000)
                   reloadInterval:
                     description: |-
                       reloadInterval defines the minimum interval at which the router is allowed to reload


### PR DESCRIPTION
## Summary

- Replace `anyOf` OpenAPI schema validation with CEL `XValidation` rule for `IngressControllerTuningOptions.maxConnections`
- The `anyOf` pattern (enum `[-1, 0]` OR range `[2000, 2000000]`) produced incomplete error messages when both branches failed: the API server only reported "must be one of: -1, 0", omitting the valid range
- The new CEL rule produces a clear, unified error message: "maxConnections must be 0, -1, or between 2000 and 2000000"
- Add 8 onCreate tests (valid and invalid values) and 3 onUpdate ratcheting tests

### Before (anyOf error)
```
spec.tuningOptions: Invalid value: "object": spec.tuningOptions in body
must validate at least one schema (anyOf)
spec.tuningOptions.maxConnections: Unsupported value: 500:
supported values: "-1", "0"
```

### After (CEL error)
```
spec.tuningOptions.maxConnections: Invalid value: "integer":
maxConnections must be 0, -1, or between 2000 and 2000000
```

## Context

The original `anyOf` was added in PR #1161 (April 2022) before CEL `XValidation` was widely adopted in this repo. The file now has 30 XValidation rules, including 3 on the adjacent `httpKeepAliveTimeout` field in the same struct. CEL and OpenAPI structural validation ratchet identically under `CRDValidationRatcheting` (GA since Kubernetes 1.30), so there is no behavioral change for existing stored objects.

## Test plan

- [x] `make update` (full codegen) completes successfully
- [x] Integration tests pass (`make -C tests test`), including:
  - Valid values: -1, 2000, 50000, 2000000
  - Invalid values: 1, 500, 1999, 3000000
  - Ratcheting: update invalid to valid, update invalid to another invalid (rejected), retain invalid while updating other fields (ratcheted)
- [x] anyOf removed from all 5 generated CRD variants (Default, CustomNoUpgrade, DevPreviewNoUpgrade, TechPreviewNoUpgrade, OKD)
- [x] CEL XValidation rule present in all 5 generated CRD variants

Bug: https://issues.redhat.com/browse/OCPBUGS-86570