### PR TITLE
[release-4.21] OCPBUGS-85149: Backport GatewayAPIWithoutOLM feature gate as disabled

### DIFF
--- a/features.md
+++ b/features.md
@@ -3,6 +3,7 @@
 | ClientsAllowCBOR| | | | | |  |
 | ClusterAPIInstall| | | | | |  |
 | EventedPLEG| | | | | |  |
+| GatewayAPIWithoutOLM| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | NewOLMBoxCutterRuntime| | | | | |  |

--- a/features/features.go
+++ b/features/features.go
@@ -945,4 +945,11 @@ var (
 								enhancementPR("https://github.com/kubernetes/enhancements/issues/4381").
 								enableForClusterProfile(Hypershift, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade, configv1.Default).
 								mustRegister()
+
+    FeatureGateGatewayAPIWithoutOLM = newFeatureGate("GatewayAPIWithoutOLM").
+                                    reportProblemsToJiraComponent("Routing").
+                                    contactPerson("miciah").
+                                    productScope(ocpSpecific).
+                                    enhancementPR("https://github.com/openshift/enhancements/pull/1933").
+                                    mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -115,6 +115,9 @@
                         "name": "GCPDualStackInstall"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "ImageModeStatusReporting"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -24,6 +24,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -33,6 +33,9 @@
                         "name": "ExternalSnapshotMetadata"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "KMSEncryptionProvider"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -115,6 +115,9 @@
                         "name": "GCPDualStackInstall"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "HyperShiftOnlyDynamicResourceAllocation"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -24,6 +24,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "HyperShiftOnlyDynamicResourceAllocation"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -33,6 +33,9 @@
                         "name": "ExternalSnapshotMetadata"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "HyperShiftOnlyDynamicResourceAllocation"
                     },
                     {


### PR DESCRIPTION
## Summary

Backport the `GatewayAPIWithoutOLM` feature gate definition to release-4.21 with all feature sets disabled. The gate is present but OFF — no behavioral change.

## Why

1. **Unblocks test backports** — [openshift/origin#31139](https://github.com/openshift/origin/pull/31139) needs the feature gate to exist so it can conditionally skip noOLM-dependent tests. Without the gate definition, the test backport can't compile.

2. **Enables cleaner future backports** — there is ongoing discussion about backporting the full noOLM / Sail Library path to 4.21 to address OLM subscription management issues (catalog source conflicts, detached subscriptions, disconnected cluster support). Having the gate already present makes that backport significantly cleaner if we decide to proceed.

Either way, this PR is safe — the gate is disabled in all feature sets and introduces no functional change.

## Changes

- Add `FeatureGateGatewayAPIWithoutOLM` to `features/features.go` with no `enableIn` call (disabled everywhere)