### PR TITLE
[release-4.20] OCPBUGS-85155: Backport GatewayAPIWithoutOLM feature gate as disabled

### DIFF
--- a/features.md
+++ b/features.md
@@ -2,6 +2,7 @@
 | ------ | --- | --- | --- | --- | --- | ---  |
 | ClusterAPIInstall| | | | | |  |
 | EventedPLEG| | | | | |  |
+| GatewayAPIWithoutOLM| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | ShortCertRotation| | | | | |  |

--- a/features/features.go
+++ b/features/features.go
@@ -846,4 +846,11 @@ var (
 						enhancementPR("https://github.com/openshift/enhancements/pull/1785").
 						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
+
+	FeatureGateGatewayAPIWithoutOLM = newFeatureGate("GatewayAPIWithoutOLM").
+						reportProblemsToJiraComponent("Routing").
+						contactPerson("miciah").
+						productScope(ocpSpecific).
+						enhancementPR("https://github.com/openshift/enhancements/pull/1933").
+						mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -95,6 +95,9 @@
                         "name": "GCPCustomAPIEndpointsInstall"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "ImageModeStatusReporting"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -22,6 +22,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -31,6 +31,9 @@
                         "name": "ExternalSnapshotMetadata"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -95,6 +95,9 @@
                         "name": "GCPCustomAPIEndpointsInstall"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "ImageModeStatusReporting"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -22,6 +22,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -31,6 +31,9 @@
                         "name": "ExternalSnapshotMetadata"
                     },
                     {
+                        "name": "GatewayAPIWithoutOLM"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {


### PR DESCRIPTION
## Summary

Backport the `GatewayAPIWithoutOLM` feature gate definition to release-4.20 with all feature sets disabled. The gate is present but OFF — no behavioral change.

## Why

1. **Unblocks test backports** — test backports that reference the `GatewayAPIWithoutOLM` feature gate need the gate definition to exist so they can compile. Without it, any noOLM-dependent test backport to 4.20 will fail.

2. **Enables cleaner future backports** — there is ongoing discussion about backporting the full noOLM / Sail Library path to 4.20 to address OLM subscription management issues (catalog source conflicts, detached subscriptions, disconnected cluster support). Having the gate already present makes that backport significantly cleaner if we decide to proceed.

Either way, this PR is safe — the gate is disabled in all feature sets and introduces no functional change.

## Changes

- Add `FeatureGateGatewayAPIWithoutOLM` to `features/features.go` with no `enableIn` call (disabled everywhere)

Mirror of https://github.com/openshift/api/pull/2864 (release-4.21)