### PR TITLE
[release-4.21] OCPBUGS-88295, OCPBUGS-88297, OCPBUGS-82146, OCPBUGS-78330, OCPBUGS-85550: Promote GatewayAPIWithoutOLM feature gate to TechPreview

### DIFF
--- a/features.md
+++ b/features.md
@@ -3,7 +3,6 @@
 | ClientsAllowCBOR| | | | | |  |
 | ClusterAPIInstall| | | | | |  |
 | EventedPLEG| | | | | |  |
-| GatewayAPIWithoutOLM| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | NewOLMBoxCutterRuntime| | | | | |  |
@@ -48,6 +47,7 @@
 | GCPCustomAPIEndpoints| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPCustomAPIEndpointsInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPDualStackInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| GatewayAPIWithoutOLM| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ImageModeStatusReporting| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | IngressControllerDynamicConfigurationManager| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsConfig| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -951,5 +951,6 @@ var (
                                     contactPerson("miciah").
                                     productScope(ocpSpecific).
                                     enhancementPR("https://github.com/openshift/enhancements/pull/1933").
+                                    enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
                                     mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -24,9 +24,6 @@
                         "name": "EventedPLEG"
                     },
                     {
-                        "name": "GatewayAPIWithoutOLM"
-                    },
-                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {
@@ -189,6 +186,9 @@
                     },
                     {
                         "name": "GatewayAPIController"
+                    },
+                    {
+                        "name": "GatewayAPIWithoutOLM"
                     },
                     {
                         "name": "HighlyAvailableArbiter"

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -33,9 +33,6 @@
                         "name": "ExternalSnapshotMetadata"
                     },
                     {
-                        "name": "GatewayAPIWithoutOLM"
-                    },
-                    {
                         "name": "KMSEncryptionProvider"
                     },
                     {
@@ -195,6 +192,9 @@
                     },
                     {
                         "name": "GatewayAPIController"
+                    },
+                    {
+                        "name": "GatewayAPIWithoutOLM"
                     },
                     {
                         "name": "HighlyAvailableArbiter"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -24,9 +24,6 @@
                         "name": "EventedPLEG"
                     },
                     {
-                        "name": "GatewayAPIWithoutOLM"
-                    },
-                    {
                         "name": "HyperShiftOnlyDynamicResourceAllocation"
                     },
                     {
@@ -174,6 +171,9 @@
                     },
                     {
                         "name": "GatewayAPIController"
+                    },
+                    {
+                        "name": "GatewayAPIWithoutOLM"
                     },
                     {
                         "name": "HighlyAvailableArbiter"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -33,9 +33,6 @@
                         "name": "ExternalSnapshotMetadata"
                     },
                     {
-                        "name": "GatewayAPIWithoutOLM"
-                    },
-                    {
                         "name": "HyperShiftOnlyDynamicResourceAllocation"
                     },
                     {
@@ -180,6 +177,9 @@
                     },
                     {
                         "name": "GatewayAPIController"
+                    },
+                    {
+                        "name": "GatewayAPIWithoutOLM"
                     },
                     {
                         "name": "HighlyAvailableArbiter"


### PR DESCRIPTION
## Summary

Promote the `GatewayAPIWithoutOLM` feature gate to `TechPreviewNoUpgrade` on release-4.21 to allow CI soak before GA promotion. This is part of an approved SBAR to backport the Sail Library (noOLM) from 4.22 to 4.19–4.21.

### Background

Gateway API on OCP 4.19–4.21 uses the Cluster Ingress Operator (CIO) to install Istio via OLM (OSSM operator). This path has several critical bugs:

- [OCPBUGS-88295](https://issues.redhat.com/browse/OCPBUGS-88295): OSSM z-stream upgrades are blocked, preventing CVE fixes from being delivered
- [OCPBUGS-82146](https://issues.redhat.com/browse/OCPBUGS-82146): OLM-related install failures
- [OCPBUGS-78330](https://issues.redhat.com/browse/OCPBUGS-78330): Hardcoded catalog source breaks disconnected environments
- [OCPBUGS-85550](https://issues.redhat.com/browse/OCPBUGS-85550): Gateway API fails on clusters without Marketplace capability

In OCP 4.22, [NE-2286](https://issues.redhat.com/browse/NE-2286) replaced OLM with the Sail Library — CIO now installs Istio directly via embedded Helm charts. This feature shipped as GA behind the `GatewayAPIWithoutOLM` feature gate.

## Rollout Plan

**Phase 1 — Land code (gate OFF)**
- https://github.com/openshift/api/pull/2864 — Add FG as disabled
- https://github.com/openshift/origin/pull/31139 — Backport Gateway API test prerequisites
- https://github.com/openshift/origin/pull/31232 — Backport noOLM test coverage and upgrade tests
- https://github.com/openshift/cluster-ingress-operator/pull/1442 — Sail Library code lands, gate OFF

**Phase 2 — TechPreview soak**
- **This PR** — FG promotion to TechPreviewNoUpgrade
- Verify CI soak in TP periodic jobs

**Phase 3 — GA promotion**
- https://github.com/openshift/cluster-ingress-operator/pull/1462 — Remove feature-set annotation from Sail Library RBAC
- https://github.com/openshift/api/pull/2865 — FG promotion to Default/GA

**Follow-up**
- https://github.com/openshift/cluster-ingress-operator/pull/1444 — Bump GWAPI CRDs to v1.4.1 and Istio to v1.28.5