### PR TITLE
STOR-2966: Promote ExternalSnapshotMetadata feature gate to TechPreviewNoUpgrade

### DIFF
--- a/features.md
+++ b/features.md
@@ -17,7 +17,6 @@
 | ConfidentialCluster| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | Example2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ExternalOIDCExternalClaimsSourcing| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
-| ExternalSnapshotMetadata| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | MachineAPIMigrationVSphere| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | NetworkConnect| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | NewOLMBoxCutterRuntime| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
@@ -62,6 +61,7 @@
 | EtcdBackendQuota| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | Example| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ExternalOIDCWithUpstreamParity| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ExternalSnapshotMetadata| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPCustomAPIEndpoints| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPCustomAPIEndpointsInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPDualStackInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -354,10 +354,10 @@ var (
 
 	FeatureGateExternalSnapshotMetadata = newFeatureGate("ExternalSnapshotMetadata").
 						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
-						contactPerson("jdobson").
+						contactPerson("rbednar").
 						productScope(kubernetes).
 						enhancementPR("https://github.com/kubernetes/enhancements/issues/3314").
-						enable(inDevPreviewNoUpgrade()).
+						enable(inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
 						mustRegister()
 
 	FeatureGateExternalOIDC = newFeatureGate("ExternalOIDC").

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
@@ -44,9 +44,6 @@
                         "name": "ExternalOIDCExternalClaimsSourcing"
                     },
                     {
-                        "name": "ExternalSnapshotMetadata"
-                    },
-                    {
                         "name": "MachineAPIMigrationAzure"
                     },
                     {
@@ -239,6 +236,9 @@
                     },
                     {
                         "name": "ExternalOIDCWithUpstreamParity"
+                    },
+                    {
+                        "name": "ExternalSnapshotMetadata"
                     },
                     {
                         "name": "GCPCustomAPIEndpoints"

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -44,9 +44,6 @@
                         "name": "ExternalOIDCExternalClaimsSourcing"
                     },
                     {
-                        "name": "ExternalSnapshotMetadata"
-                    },
-                    {
                         "name": "HyperShiftOnlyDynamicResourceAllocation"
                     },
                     {
@@ -215,6 +212,9 @@
                     },
                     {
                         "name": "ExternalOIDCWithUpstreamParity"
+                    },
+                    {
+                        "name": "ExternalSnapshotMetadata"
                     },
                     {
                         "name": "GCPCustomAPIEndpoints"


### PR DESCRIPTION
## Summary

- Promotes the `ExternalSnapshotMetadata` feature gate from `DevPreviewNoUpgrade` to `TechPreviewNoUpgrade` for OCP 5.0
- Updates `contactPerson` from `jdobson` to `rbednar`
- Regenerates payload featuregate manifests

## Context

This is part of the [STOR-2900](https://redhat.atlassian.net/browse/STOR-2900) epic to graduate Changed Block Tracking (CBT) from Developer Preview to Tech Preview in OpenShift 5.0.

**Jira:** https://redhat.atlassian.net/browse/STOR-2966

The upstream [KEP 3314 (Changed Block Tracking)](https://github.com/kubernetes/enhancements/issues/3314) has reached beta status in Kubernetes 1.36, making this promotion appropriate.

## Changes

- `features/features.go`: Changed `contactPerson("jdobson")` to `contactPerson("rbednar")` and changed `enable(inDevPreviewNoUpgrade())` to `enable(inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade())`
- `features.md`: Regenerated (ExternalSnapshotMetadata moved to TechPreview+DevPreview table)
- `payload-manifests/featuregates/*.yaml`: Regenerated (ExternalSnapshotMetadata added to TechPreviewNoUpgrade enabled list)