### PR TITLE
NO-JIRA: tools: fix verify-codegen in git worktrees

### DIFF
--- a/tools/codegen/pkg/schemacheck/generator.go
+++ b/tools/codegen/pkg/schemacheck/generator.go
@@ -204,7 +204,8 @@ type schemaCheckGenerationContext struct {
 // It finds all CRD manifests, loads the data and the original version of the manifest for comparison.
 func loadSchemaCheckGenerationContextsForVersion(version generation.APIVersionContext, gitBaseSHA string) ([]schemaCheckGenerationContext, error) {
 	repo, err := git.PlainOpenWithOptions(version.Path, &git.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not open git repository at %s: %w", version.Path, err)

--- a/tools/codegen/pkg/utils/git_diff.go
+++ b/tools/codegen/pkg/utils/git_diff.go
@@ -15,7 +15,8 @@ import (
 // committed and current file contents is returned.
 func GitDiff(packagePath, fileName string) (string, error) {
 	repo, err := git.PlainOpenWithOptions(packagePath, &git.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
 	})
 	if err != nil {
 		return "", fmt.Errorf("error opening parent git repository: %w", err)


### PR DESCRIPTION
In a git worktree, .git is a file containing a `gitdir:` pointer to a worktree-specific directory (e.g. `.git/worktrees/<name>/`), not the usual .git directory. Set EnableDotGitCommonDir: true on both PlainOpenWithOptions call sites so that go-git reads the commondir file and overlays the shared repository, allowing it to resolve refs in linked worktrees.

See: https://pkg.go.dev/github.com/go-git/go-git/v5#PlainOpenOptions
