### PR TITLE
Treat x-validations as a map when merging for manifest merge

### DIFF
--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses-CustomNoUpgrade.crd.yaml
@@ -81,6 +81,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'privateZoneIAMRole must be a valid AWS IAM role
                             ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                        - message: 'privateZoneIAMRole must be a valid AWS IAM role
+                            ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                     type: object
                   type:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses-DevPreviewNoUpgrade.crd.yaml
@@ -81,6 +81,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'privateZoneIAMRole must be a valid AWS IAM role
                             ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                        - message: 'privateZoneIAMRole must be a valid AWS IAM role
+                            ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                     type: object
                   type:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses-TechPreviewNoUpgrade.crd.yaml
@@ -81,6 +81,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'privateZoneIAMRole must be a valid AWS IAM role
                             ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                        - message: 'privateZoneIAMRole must be a valid AWS IAM role
+                            ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                     type: object
                   type:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1084,6 +1084,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: Cannot add and remove vCenters at the same time
                           rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x, self.exists(y,
                             y.server == x.server)) : true'
@@ -1100,6 +1103,9 @@ spec:
                       rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                 type: object
                 x-kubernetes-validations:
+                - message: vcenters can have at most 1 item when configured post-install
+                  rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                    && size(self.vsphere.vcenters) < 2) : true'
                 - message: vcenters is required once set and cannot be removed
                   rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                     : true'

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1018,6 +1018,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: vcenters must have unique server values
                           rule: self.all(x, self.exists_one(y, y.server == x.server))
                     type: object

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1084,6 +1084,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: Cannot add and remove vCenters at the same time
                           rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x, self.exists(y,
                             y.server == x.server)) : true'
@@ -1100,6 +1103,9 @@ spec:
                       rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                 type: object
                 x-kubernetes-validations:
+                - message: vcenters can have at most 1 item when configured post-install
+                  rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                    && size(self.vsphere.vcenters) < 2) : true'
                 - message: vcenters is required once set and cannot be removed
                   rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                     : true'

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
@@ -1018,6 +1018,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: vcenters must have unique server values
                           rule: self.all(x, self.exists_one(y, y.server == x.server))
                     type: object

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1084,6 +1084,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: Cannot add and remove vCenters at the same time
                           rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x, self.exists(y,
                             y.server == x.server)) : true'
@@ -1100,6 +1103,9 @@ spec:
                       rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                 type: object
                 x-kubernetes-validations:
+                - message: vcenters can have at most 1 item when configured post-install
+                  rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                    && size(self.vsphere.vcenters) < 2) : true'
                 - message: vcenters is required once set and cannot be removed
                   rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                     : true'

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -137,6 +137,9 @@ spec:
                                 x-kubernetes-validations:
                                 - message: 'privateZoneIAMRole must be a valid AWS
                                     IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                                   rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
@@ -1373,6 +1376,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: Cannot add and remove vCenters at the same
                                     time
                                   rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x,
@@ -1393,6 +1400,10 @@ spec:
                               rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                         type: object
                         x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                            && size(self.vsphere.vcenters) < 2) : true'
                         - message: vcenters is required once set and cannot be removed
                           rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                             : true'

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1305,6 +1305,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: vcenters must have unique server values
                                   rule: self.all(x, self.exists_one(y, y.server ==
                                     x.server))

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -137,6 +137,9 @@ spec:
                                 x-kubernetes-validations:
                                 - message: 'privateZoneIAMRole must be a valid AWS
                                     IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                                   rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
@@ -1373,6 +1376,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: Cannot add and remove vCenters at the same
                                     time
                                   rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x,
@@ -1393,6 +1400,10 @@ spec:
                               rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                         type: object
                         x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                            && size(self.vsphere.vcenters) < 2) : true'
                         - message: vcenters is required once set and cannot be removed
                           rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                             : true'

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
@@ -1305,6 +1305,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: vcenters must have unique server values
                                   rule: self.all(x, self.exists_one(y, y.server ==
                                     x.server))

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -137,6 +137,9 @@ spec:
                                 x-kubernetes-validations:
                                 - message: 'privateZoneIAMRole must be a valid AWS
                                     IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                                   rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
@@ -1373,6 +1376,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: Cannot add and remove vCenters at the same
                                     time
                                   rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x,
@@ -1393,6 +1400,10 @@ spec:
                               rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                         type: object
                         x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                            && size(self.vsphere.vcenters) < 2) : true'
                         - message: vcenters is required once set and cannot be removed
                           rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                             : true'

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
@@ -135,6 +135,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
                             format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
+                        - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
+                            format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f|aws-eusc):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
                     type: object
                   azure:

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
@@ -135,6 +135,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
                             format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
+                        - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
+                            format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f|aws-eusc):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
                     type: object
                   azure:

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
@@ -135,6 +135,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
                             format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
+                        - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
+                            format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f|aws-eusc):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
                     type: object
                   azure:

--- a/payload-manifests/crds/0000_10_config-operator_01_dnses-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dnses-CustomNoUpgrade.crd.yaml
@@ -81,6 +81,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'privateZoneIAMRole must be a valid AWS IAM role
                             ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                        - message: 'privateZoneIAMRole must be a valid AWS IAM role
+                            ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                     type: object
                   type:

--- a/payload-manifests/crds/0000_10_config-operator_01_dnses-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dnses-DevPreviewNoUpgrade.crd.yaml
@@ -81,6 +81,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'privateZoneIAMRole must be a valid AWS IAM role
                             ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                        - message: 'privateZoneIAMRole must be a valid AWS IAM role
+                            ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                     type: object
                   type:

--- a/payload-manifests/crds/0000_10_config-operator_01_dnses-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dnses-TechPreviewNoUpgrade.crd.yaml
@@ -81,6 +81,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'privateZoneIAMRole must be a valid AWS IAM role
                             ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                        - message: 'privateZoneIAMRole must be a valid AWS IAM role
+                            ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                     type: object
                   type:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1084,6 +1084,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: Cannot add and remove vCenters at the same time
                           rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x, self.exists(y,
                             y.server == x.server)) : true'
@@ -1100,6 +1103,9 @@ spec:
                       rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                 type: object
                 x-kubernetes-validations:
+                - message: vcenters can have at most 1 item when configured post-install
+                  rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                    && size(self.vsphere.vcenters) < 2) : true'
                 - message: vcenters is required once set and cannot be removed
                   rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                     : true'

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1018,6 +1018,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: vcenters must have unique server values
                           rule: self.all(x, self.exists_one(y, y.server == x.server))
                     type: object

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1084,6 +1084,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: Cannot add and remove vCenters at the same time
                           rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x, self.exists(y,
                             y.server == x.server)) : true'
@@ -1100,6 +1103,9 @@ spec:
                       rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                 type: object
                 x-kubernetes-validations:
+                - message: vcenters can have at most 1 item when configured post-install
+                  rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                    && size(self.vsphere.vcenters) < 2) : true'
                 - message: vcenters is required once set and cannot be removed
                   rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                     : true'

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
@@ -1018,6 +1018,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: vcenters must have unique server values
                           rule: self.all(x, self.exists_one(y, y.server == x.server))
                     type: object

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1084,6 +1084,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
+                        - message: vcenters cannot be added or removed once set
+                          rule: 'size(self) != size(oldSelf) ? size(oldSelf) == 0
+                            && size(self) < 2 : true'
                         - message: Cannot add and remove vCenters at the same time
                           rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x, self.exists(y,
                             y.server == x.server)) : true'
@@ -1100,6 +1103,9 @@ spec:
                       rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                 type: object
                 x-kubernetes-validations:
+                - message: vcenters can have at most 1 item when configured post-install
+                  rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                    && size(self.vsphere.vcenters) < 2) : true'
                 - message: vcenters is required once set and cannot be removed
                   rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                     : true'

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
@@ -135,6 +135,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
                             format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
+                        - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
+                            format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f|aws-eusc):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
                     type: object
                   azure:

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
@@ -135,6 +135,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
                             format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
+                        - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
+                            format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f|aws-eusc):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
                     type: object
                   azure:

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
@@ -135,6 +135,9 @@ spec:
                         x-kubernetes-validations:
                         - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
                             format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
+                          rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
+                        - message: 'kmsKeyARN must be a valid AWS KMS key ARN in the
+                            format: arn:<partition>:kms:<region>:<account-id>:(key|alias)/<key-id-or-alias>'
                           rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f|aws-eusc):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)/.*$')
                     type: object
                   azure:

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -137,6 +137,9 @@ spec:
                                 x-kubernetes-validations:
                                 - message: 'privateZoneIAMRole must be a valid AWS
                                     IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                                   rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
@@ -1373,6 +1376,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: Cannot add and remove vCenters at the same
                                     time
                                   rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x,
@@ -1393,6 +1400,10 @@ spec:
                               rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                         type: object
                         x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                            && size(self.vsphere.vcenters) < 2) : true'
                         - message: vcenters is required once set and cannot be removed
                           rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                             : true'

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1305,6 +1305,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: vcenters must have unique server values
                                   rule: self.all(x, self.exists_one(y, y.server ==
                                     x.server))

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -137,6 +137,9 @@ spec:
                                 x-kubernetes-validations:
                                 - message: 'privateZoneIAMRole must be a valid AWS
                                     IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                                   rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
@@ -1373,6 +1376,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: Cannot add and remove vCenters at the same
                                     time
                                   rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x,
@@ -1393,6 +1400,10 @@ spec:
                               rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                         type: object
                         x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                            && size(self.vsphere.vcenters) < 2) : true'
                         - message: vcenters is required once set and cannot be removed
                           rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                             : true'

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
@@ -1305,6 +1305,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: vcenters must have unique server values
                                   rule: self.all(x, self.exists_one(y, y.server ==
                                     x.server))

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -137,6 +137,9 @@ spec:
                                 x-kubernetes-validations:
                                 - message: 'privateZoneIAMRole must be a valid AWS
                                     IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
+                                  rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.*$')
+                                - message: 'privateZoneIAMRole must be a valid AWS
+                                    IAM role ARN in the format: arn:<partition>:iam::<account-id>:role/<role-name>'
                                   rule: matches(self, '^arn:(aws|aws-cn|aws-us-gov|aws-eusc):iam::[0-9]{12}:role/.*$')
                             type: object
                           type:
@@ -1373,6 +1376,10 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
                                 - message: Cannot add and remove vCenters at the same
                                     time
                                   rule: 'size(self) >= size(oldSelf) ? oldSelf.all(x,
@@ -1393,6 +1400,10 @@ spec:
                               rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
                         type: object
                         x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? (has(self.vsphere.vcenters)
+                            && size(self.vsphere.vcenters) < 2) : true'
                         - message: vcenters is required once set and cannot be removed
                           rule: 'oldSelf.?vsphere.vcenters.hasValue() ? self.?vsphere.vcenters.hasValue()
                             : true'

--- a/tools/codegen/pkg/manifestmerge/crd-schema.json
+++ b/tools/codegen/pkg/manifestmerge/crd-schema.json
@@ -727,7 +727,10 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "atomic"
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-list-map-keys": [
+              "rule"
+            ]
           }
         },
         "type": "object"


### PR DESCRIPTION
When gated manifests contain different XValidations, because the list is currently treated as atomic, last write wins. This means we lose some XValidations during the merge. The first commit here switches the manifest merge to treat `x-kubernetes-validations` as a map so that we can merge multiple different opinions together.

CC @miyadav This should fix your issue with capabilities