### PR TITLE
SSCSI-245: Rename rotationPollIntervalSeconds to minimumRefreshAge

### DIFF
--- a/operator/v1/tests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
@@ -62,7 +62,7 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 300
+                  minimumRefreshAge: 300
       expectedError: "Invalid value: \"object\": secretsStore must be set if driverType is 'SecretsStore', but remain unset otherwise"
     - name: Should reject secrets-store name with non-SecretsStore driverType
       initial: |
@@ -87,7 +87,7 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 300
+                  minimumRefreshAge: 300
       expectedError: "driverType 'SecretsStore' requires metadata.name 'secrets-store.csi.k8s.io'"
     - name: Should allow secrets-store name without driverType for backward compatibility
       initial: |
@@ -214,7 +214,7 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 300
+                  minimumRefreshAge: 300
               tokenRequests:
                 type: Managed
                 managed:
@@ -236,7 +236,7 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 300
+                  minimumRefreshAge: 300
               tokenRequests:
                 type: Managed
                 managed:
@@ -496,7 +496,7 @@ tests:
               secretRotation:
                 type: Custom
       expectedError: "custom must be set when type is 'Custom', and must not be set otherwise"
-    - name: Should reject rotationPollIntervalSeconds below 1
+    - name: Should reject minimumRefreshAge below 1
       initial: |
         apiVersion: operator.openshift.io/v1
         kind: ClusterCSIDriver
@@ -509,9 +509,9 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 0
-      expectedError: "spec.driverConfig.secretsStore.secretRotation.custom.rotationPollIntervalSeconds: Invalid value"
-    - name: Should reject rotationPollIntervalSeconds above 31560000
+                  minimumRefreshAge: 0
+      expectedError: "spec.driverConfig.secretsStore.secretRotation.custom.minimumRefreshAge: Invalid value"
+    - name: Should reject minimumRefreshAge above 31560000
       initial: |
         apiVersion: operator.openshift.io/v1
         kind: ClusterCSIDriver
@@ -524,8 +524,8 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 31560001
-      expectedError: "spec.driverConfig.secretsStore.secretRotation.custom.rotationPollIntervalSeconds: Invalid value"
+                  minimumRefreshAge: 31560001
+      expectedError: "spec.driverConfig.secretsStore.secretRotation.custom.minimumRefreshAge: Invalid value"
     - name: Should reject Managed tokenRequests without managed field
       initial: |
         apiVersion: operator.openshift.io/v1
@@ -697,7 +697,7 @@ tests:
               secretRotation:
                 type: Custom
                 custom:
-                  rotationPollIntervalSeconds: 300
+                  minimumRefreshAge: 300
       expectedError: "tokenRequests type cannot be changed from Managed"
     - name: Should allow changing tokenRequests type from Unmanaged to Managed
       initial: |

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -506,16 +506,20 @@ type SecretsStoreSecretRotation struct {
 // CustomSecretRotation holds configuration for custom secret rotation behavior.
 // +kubebuilder:validation:MinProperties=1
 type CustomSecretRotation struct {
-	// rotationPollIntervalSeconds is the minimum time in seconds between secret
-	// rotation attempts. The driver skips provider calls if less than this interval
-	// has elapsed since the last successful rotation.
+	// minimumRefreshAge is the minimum time in seconds between secret
+	// rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+	// checks whether this interval has elapsed since the last successful provider
+	// call. If it has, the driver contacts the secret provider to fetch the latest
+	// secret values and updates the mounted volume.
+	// Setting this value below the kubelet syncFrequency (default: 1 minute)
+	// has no additional effect on the actual rotation cadence.
 	// Must be at least 1 second and no more than 31560000 seconds (~1 year).
 	// When omitted, this means no opinion and the platform is left to choose a
 	// reasonable default, which is subject to change over time.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=31560000
 	// +optional
-	RotationPollIntervalSeconds int32 `json:"rotationPollIntervalSeconds,omitempty"`
+	MinimumRefreshAge int32 `json:"minimumRefreshAge,omitempty"`
 }
 
 // SecretsStoreTokenRequest specifies a service account token audience configuration

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -520,6 +520,14 @@ type CustomSecretRotation struct {
 	// +kubebuilder:validation:Maximum=31560000
 	// +optional
 	MinimumRefreshAge int32 `json:"minimumRefreshAge,omitempty"`
+
+	// --- TOMBSTONE ---
+	// rotationPollIntervalSeconds was the previous name for minimumRefreshAge.
+	// The field has been renamed to better reflect its semantics.
+	// The JSON key is reserved to prevent reuse.
+	//
+	// +optional
+	// RotationPollIntervalSeconds int32 `json:"rotationPollIntervalSeconds,omitempty"`
 }
 
 // SecretsStoreTokenRequest specifies a service account token audience configuration

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-Default.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-OKD.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-OKD.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
@@ -258,11 +258,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
@@ -258,11 +258,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/VSphereConfigurableMaxAllowedBlockVolumesPerNode.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/VSphereConfigurableMaxAllowedBlockVolumesPerNode.yaml
@@ -254,11 +254,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -569,8 +569,8 @@ func (ClusterCSIDriverStatus) SwaggerDoc() map[string]string {
 }
 
 var map_CustomSecretRotation = map[string]string{
-	"":                            "CustomSecretRotation holds configuration for custom secret rotation behavior.",
-	"rotationPollIntervalSeconds": "rotationPollIntervalSeconds is the minimum time in seconds between secret rotation attempts. The driver skips provider calls if less than this interval has elapsed since the last successful rotation. Must be at least 1 second and no more than 31560000 seconds (~1 year). When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.",
+	"":                  "CustomSecretRotation holds configuration for custom secret rotation behavior.",
+	"minimumRefreshAge": "minimumRefreshAge is the minimum time in seconds between secret rotation attempts. Each time kubelet calls NodePublishVolume, the driver checks whether this interval has elapsed since the last successful provider call. If it has, the driver contacts the secret provider to fetch the latest secret values and updates the mounted volume. Setting this value below the kubelet syncFrequency (default: 1 minute) has no additional effect on the actual rotation cadence. Must be at least 1 second and no more than 31560000 seconds (~1 year). When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time.",
 }
 
 func (CustomSecretRotation) SwaggerDoc() map[string]string {

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-Default.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-Default.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-DevPreviewNoUpgrade.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-OKD.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.

--- a/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_50_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
@@ -278,11 +278,15 @@ spec:
                               Only valid when type is "Custom".
                             minProperties: 1
                             properties:
-                              rotationPollIntervalSeconds:
+                              minimumRefreshAge:
                                 description: |-
-                                  rotationPollIntervalSeconds is the minimum time in seconds between secret
-                                  rotation attempts. The driver skips provider calls if less than this interval
-                                  has elapsed since the last successful rotation.
+                                  minimumRefreshAge is the minimum time in seconds between secret
+                                  rotation attempts. Each time kubelet calls NodePublishVolume, the driver
+                                  checks whether this interval has elapsed since the last successful provider
+                                  call. If it has, the driver contacts the secret provider to fetch the latest
+                                  secret values and updates the mounted volume.
+                                  Setting this value below the kubelet syncFrequency (default: 1 minute)
+                                  has no additional effect on the actual rotation cadence.
                                   Must be at least 1 second and no more than 31560000 seconds (~1 year).
                                   When omitted, this means no opinion and the platform is left to choose a
                                   reasonable default, which is subject to change over time.


### PR DESCRIPTION
## Summary
Renames `CustomSecretRotation.rotationPollIntervalSeconds` to
`CustomSecretRotation.minimumRefreshAge`.

The driver only contacts the secret provider when the cached value is older than this threshold. The new
name makes that intent clear at the API level.

No behaviour change; only the API field name and JSON key are updated.

- See https://github.com/openshift/enhancements/pull/2012#discussion_r3473758233 for the decision. 
- Follow up of https://github.com/openshift/api/pull/2846
