### PR TITLE
CORENET-6714 Adding documentation 

### DIFF
--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -331,6 +331,9 @@ type NetworkObservabilitySpec struct {
 	// Valid values are "InstallAndEnable" and "NoAction".
 	// When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
 	// When set to "NoAction", nothing will be done regarding Network observability.
+	// During the installation of NetworkObservability, the platform checks for any existing manual installations.
+	// If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+	// If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
 	// +required
 	InstallationPolicy NetworkObservabilityInstallationPolicy `json:"installationPolicy,omitempty"`
 }

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-DevPreviewNoUpgrade.crd.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction

--- a/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/NetworkObservabilityInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/NetworkObservabilityInstall.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -2645,7 +2645,7 @@ func (NetworkMigration) SwaggerDoc() map[string]string {
 
 var map_NetworkObservabilitySpec = map[string]string{
 	"":                   "NetworkObservabilitySpec defines the configuration for network observability installation",
-	"installationPolicy": "installationPolicy controls whether network observability is installed during cluster deployment. Valid values are \"InstallAndEnable\" and \"NoAction\". When set to \"InstallAndEnable\", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again. When set to \"NoAction\", nothing will be done regarding Network observability.",
+	"installationPolicy": "installationPolicy controls whether network observability is installed during cluster deployment. Valid values are \"InstallAndEnable\" and \"NoAction\". When set to \"InstallAndEnable\", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again. When set to \"NoAction\", nothing will be done regarding Network observability. During the installation of NetworkObservability, the platform checks for any existing manual installations. If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used. If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.",
 }
 
 func (NetworkObservabilitySpec) SwaggerDoc() map[string]string {

--- a/payload-manifests/crds/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction

--- a/payload-manifests/crds/0000_10_config-operator_01_networks-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks-DevPreviewNoUpgrade.crd.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction

--- a/payload-manifests/crds/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -273,6 +273,9 @@ spec:
                       Valid values are "InstallAndEnable" and "NoAction".
                       When set to "InstallAndEnable", ensure that network observability will be installed and enabled on the cluster. If already installed, no action taken, but if it gets uninstalled, it will install it again.
                       When set to "NoAction", nothing will be done regarding Network observability.
+                      During the installation of NetworkObservability, the platform checks for any existing manual installations.
+                      If a successful installation using the OLMv0 or OLMv1 API is detected, it will be used.
+                      If the platform cannot determine how the current version was installed, or if the existing installation is incomplete, the installation process will stop.
                     enum:
                     - InstallAndEnable
                     - NoAction


### PR DESCRIPTION
# Summary

Adding documentation on the network observability installation field related to how some cases will be handled.

The first goal of this cases is to prevent altering something that was changed by a user.