### PR TITLE
Rename "Insights Advisor" to "Red Hat Lightspeed Advisor" in API docs

### DIFF
--- a/insights/v1/types_insights.go
+++ b/insights/v1/types_insights.go
@@ -369,7 +369,7 @@ type HealthCheck struct {
 	// The value represents the severity of the issue.
 	// +required
 	TotalRisk TotalRisk `json:"totalRisk,omitempty"`
-	// advisorURI is required field that provides the URL link to the Insights Advisor.
+	// advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
 	// The link must be a valid HTTPS URL and the maximum length is 2048 characters.
 	// +kubebuilder:validation:XValidation:rule=`isURL(self) && url(self).getScheme() == "https"`,message=`advisorURI must be a valid HTTPS URL (e.g., https://example.com)`
 	// +kubebuilder:validation:MinLength=1

--- a/insights/v1/zz_generated.crd-manifests/0000_10_insights_01_datagathers.crd.yaml
+++ b/insights/v1/zz_generated.crd-manifests/0000_10_insights_01_datagathers.crd.yaml
@@ -463,7 +463,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           minLength: 1

--- a/insights/v1/zz_generated.featuregated-crd-manifests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
+++ b/insights/v1/zz_generated.featuregated-crd-manifests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
@@ -464,7 +464,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           minLength: 1

--- a/insights/v1/zz_generated.swagger_doc_generated.go
+++ b/insights/v1/zz_generated.swagger_doc_generated.go
@@ -102,7 +102,7 @@ var map_HealthCheck = map[string]string{
 	"":            "HealthCheck represents an Insights health check attributes.",
 	"description": "description is required field that provides basic description of the healthcheck. It must contain at least 10 characters and may not exceed 2048 characters.",
 	"totalRisk":   "totalRisk is the required field of the healthcheck. It is indicator of the total risk posed by the detected issue; combination of impact and likelihood. Allowed values are Low, Moderate, Important and Critical. The value represents the severity of the issue.",
-	"advisorURI":  "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+	"advisorURI":  "advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
 }
 
 func (HealthCheck) SwaggerDoc() map[string]string {

--- a/insights/v1alpha1/types_insights.go
+++ b/insights/v1alpha1/types_insights.go
@@ -280,7 +280,7 @@ type HealthCheck struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4
 	TotalRisk int32 `json:"totalRisk"`
-	// advisorURI is required field that provides the URL link to the Insights Advisor.
+	// advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
 	// The link must be a valid HTTPS URL and the maximum length is 2048 characters.
 	// +kubebuilder:validation:XValidation:rule=`isURL(self) && url(self).getScheme() == "https"`,message=`advisorURI must be a valid HTTPS URL (e.g., https://example.com)`
 	// +kubebuilder:validation:MaxLength=2048
@@ -288,7 +288,7 @@ type HealthCheck struct {
 	AdvisorURI string `json:"advisorURI"`
 	// state determines what the current state of the health check is.
 	// Health check is enabled by default and can be disabled
-	// by the user in the Insights advisor user interface.
+	// by the user in the Red Hat Lightspeed Advisor UI.
 	// +required
 	State HealthCheckState `json:"state"`
 }

--- a/insights/v1alpha1/zz_generated.crd-manifests/0000_10_insights_01_datagathers.crd.yaml
+++ b/insights/v1alpha1/zz_generated.crd-manifests/0000_10_insights_01_datagathers.crd.yaml
@@ -385,7 +385,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           type: string
@@ -402,7 +402,7 @@ spec:
                           description: |-
                             state determines what the current state of the health check is.
                             Health check is enabled by default and can be disabled
-                            by the user in the Insights advisor user interface.
+                            by the user in the Red Hat Lightspeed Advisor UI.
                           enum:
                           - Enabled
                           - Disabled

--- a/insights/v1alpha1/zz_generated.featuregated-crd-manifests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
+++ b/insights/v1alpha1/zz_generated.featuregated-crd-manifests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
@@ -386,7 +386,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           type: string
@@ -403,7 +403,7 @@ spec:
                           description: |-
                             state determines what the current state of the health check is.
                             Health check is enabled by default and can be disabled
-                            by the user in the Insights advisor user interface.
+                            by the user in the Red Hat Lightspeed Advisor UI.
                           enum:
                           - Enabled
                           - Disabled

--- a/insights/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/insights/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -84,8 +84,8 @@ var map_HealthCheck = map[string]string{
 	"":            "healthCheck represents an Insights health check attributes.",
 	"description": "description provides basic description of the healtcheck.",
 	"totalRisk":   "totalRisk of the healthcheck. Indicator of the total risk posed by the detected issue; combination of impact and likelihood. The values can be from 1 to 4, and the higher the number, the more important the issue.",
-	"advisorURI":  "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
-	"state":       "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+	"advisorURI":  "advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+	"state":       "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Red Hat Lightspeed Advisor UI.",
 }
 
 func (HealthCheck) SwaggerDoc() map[string]string {

--- a/insights/v1alpha2/types_insights.go
+++ b/insights/v1alpha2/types_insights.go
@@ -355,7 +355,7 @@ type HealthCheck struct {
 	// The value represents the severity of the issue.
 	// +required
 	TotalRisk TotalRisk `json:"totalRisk"`
-	// advisorURI is required field that provides the URL link to the Insights Advisor.
+	// advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
 	// The link must be a valid HTTPS URL and the maximum length is 2048 characters.
 	// +kubebuilder:validation:XValidation:rule=`isURL(self) && url(self).getScheme() == "https"`,message=`advisorURI must be a valid HTTPS URL (e.g., https://example.com)`
 	// +kubebuilder:validation:MaxLength=2048

--- a/insights/v1alpha2/zz_generated.crd-manifests/0000_10_insights_01_datagathers.crd.yaml
+++ b/insights/v1alpha2/zz_generated.crd-manifests/0000_10_insights_01_datagathers.crd.yaml
@@ -450,7 +450,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           type: string

--- a/insights/v1alpha2/zz_generated.featuregated-crd-manifests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
+++ b/insights/v1alpha2/zz_generated.featuregated-crd-manifests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
@@ -451,7 +451,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           type: string

--- a/insights/v1alpha2/zz_generated.swagger_doc_generated.go
+++ b/insights/v1alpha2/zz_generated.swagger_doc_generated.go
@@ -102,7 +102,7 @@ var map_HealthCheck = map[string]string{
 	"":            "healthCheck represents an Insights health check attributes.",
 	"description": "description is required field that provides basic description of the healtcheck. It must contain at least 10 characters and may not exceed 2048 characters.",
 	"totalRisk":   "totalRisk is the required field of the healthcheck. It is indicator of the total risk posed by the detected issue; combination of impact and likelihood. Allowed values are Low, Medium, Important and Critical. The value represents the severity of the issue.",
-	"advisorURI":  "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+	"advisorURI":  "advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
 }
 
 func (HealthCheck) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -34167,7 +34167,7 @@ func schema_openshift_api_insights_v1_HealthCheck(ref common.ReferenceCallback) 
 					},
 					"advisorURI": {
 						SchemaProps: spec.SchemaProps{
-							Description: "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+							Description: "advisorURI is a required field that provides the URL link to the Red\u00a0Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -34746,7 +34746,7 @@ func schema_openshift_api_insights_v1alpha1_HealthCheck(ref common.ReferenceCall
 					},
 					"advisorURI": {
 						SchemaProps: spec.SchemaProps{
-							Description: "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+							Description: "advisorURI is a required field that provides the URL link to the Red\u00a0Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -34754,7 +34754,7 @@ func schema_openshift_api_insights_v1alpha1_HealthCheck(ref common.ReferenceCall
 					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
-							Description: "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+							Description: "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Red\u00a0Hat Lightspeed Advisor UI.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -35392,7 +35392,7 @@ func schema_openshift_api_insights_v1alpha2_HealthCheck(ref common.ReferenceCall
 					},
 					"advisorURI": {
 						SchemaProps: spec.SchemaProps{
-							Description: "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+							Description: "advisorURI is a required field that provides the URL link to the Red\u00a0Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -56962,7 +56962,7 @@ func schema_openshift_api_operator_v1_HealthCheck(ref common.ReferenceCallback) 
 					},
 					"advisorURI": {
 						SchemaProps: spec.SchemaProps{
-							Description: "advisorURI provides the URL link to the Insights Advisor.",
+							Description: "advisorURI provides the URL link to the Red\u00a0Hat Lightspeed Advisor UI.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -56970,7 +56970,7 @@ func schema_openshift_api_operator_v1_HealthCheck(ref common.ReferenceCallback) 
 					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
-							Description: "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+							Description: "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Red\u00a0Hat Lightspeed Advisor UI.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -19174,7 +19174,7 @@
       ],
       "properties": {
         "advisorURI": {
-          "description": "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+          "description": "advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
           "type": "string"
         },
         "description": {
@@ -19517,7 +19517,7 @@
       ],
       "properties": {
         "advisorURI": {
-          "description": "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+          "description": "advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
           "type": "string",
           "default": ""
         },
@@ -19527,7 +19527,7 @@
           "default": ""
         },
         "state": {
-          "description": "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+          "description": "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Red Hat Lightspeed Advisor UI.",
           "type": "string",
           "default": ""
         },
@@ -19897,7 +19897,7 @@
       ],
       "properties": {
         "advisorURI": {
-          "description": "advisorURI is required field that provides the URL link to the Insights Advisor. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
+          "description": "advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI. The link must be a valid HTTPS URL and the maximum length is 2048 characters.",
           "type": "string",
           "default": ""
         },
@@ -33039,7 +33039,7 @@
       ],
       "properties": {
         "advisorURI": {
-          "description": "advisorURI provides the URL link to the Insights Advisor.",
+          "description": "advisorURI provides the URL link to the Red Hat Lightspeed Advisor UI.",
           "type": "string",
           "default": ""
         },
@@ -33049,7 +33049,7 @@
           "default": ""
         },
         "state": {
-          "description": "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+          "description": "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Red Hat Lightspeed Advisor UI.",
           "type": "string",
           "default": ""
         },

--- a/operator/v1/types_insights.go
+++ b/operator/v1/types_insights.go
@@ -96,13 +96,13 @@ type HealthCheck struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=4
 	TotalRisk int32 `json:"totalRisk"`
-	// advisorURI provides the URL link to the Insights Advisor.
+	// advisorURI provides the URL link to the Red Hat Lightspeed Advisor UI.
 	// +required
 	// +kubebuilder:validation:Pattern=`^https:\/\/\S+`
 	AdvisorURI string `json:"advisorURI"`
 	// state determines what the current state of the health check is.
 	// Health check is enabled by default and can be disabled
-	// by the user in the Insights advisor user interface.
+	// by the user in the Red Hat Lightspeed Advisor UI.
 	// +required
 	State HealthCheckState `json:"state"`
 }

--- a/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
@@ -307,8 +307,8 @@ spec:
                         attributes.
                       properties:
                         advisorURI:
-                          description: advisorURI provides the URL link to the Insights
-                            Advisor.
+                          description: advisorURI provides the URL link to the Red Hat
+                            Lightspeed Advisor UI.
                           pattern: ^https:\/\/\S+
                           type: string
                         description:
@@ -321,7 +321,7 @@ spec:
                           description: |-
                             state determines what the current state of the health check is.
                             Health check is enabled by default and can be disabled
-                            by the user in the Insights advisor user interface.
+                            by the user in the Red Hat Lightspeed Advisor UI.
                           enum:
                           - Enabled
                           - Disabled

--- a/operator/v1/zz_generated.featuregated-crd-manifests/insightsoperators.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/insightsoperators.operator.openshift.io/AAA_ungated.yaml
@@ -308,8 +308,8 @@ spec:
                         attributes.
                       properties:
                         advisorURI:
-                          description: advisorURI provides the URL link to the Insights
-                            Advisor.
+                          description: advisorURI provides the URL link to the Red Hat
+                            Lightspeed Advisor UI.
                           pattern: ^https:\/\/\S+
                           type: string
                         description:
@@ -322,7 +322,7 @@ spec:
                           description: |-
                             state determines what the current state of the health check is.
                             Health check is enabled by default and can be disabled
-                            by the user in the Insights advisor user interface.
+                            by the user in the Red Hat Lightspeed Advisor UI.
                           enum:
                           - Enabled
                           - Disabled

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1342,8 +1342,8 @@ var map_HealthCheck = map[string]string{
 	"":            "healthCheck represents an Insights health check attributes.",
 	"description": "description provides basic description of the healtcheck.",
 	"totalRisk":   "totalRisk of the healthcheck. Indicator of the total risk posed by the detected issue; combination of impact and likelihood. The values can be from 1 to 4, and the higher the number, the more important the issue.",
-	"advisorURI":  "advisorURI provides the URL link to the Insights Advisor.",
-	"state":       "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+	"advisorURI":  "advisorURI provides the URL link to the Red Hat Lightspeed Advisor UI.",
+	"state":       "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Red Hat Lightspeed Advisor UI.",
 }
 
 func (HealthCheck) SwaggerDoc() map[string]string {

--- a/payload-manifests/crds/0000_10_insights_01_datagathers.crd.yaml
+++ b/payload-manifests/crds/0000_10_insights_01_datagathers.crd.yaml
@@ -463,7 +463,7 @@ spec:
                       properties:
                         advisorURI:
                           description: |-
-                            advisorURI is required field that provides the URL link to the Insights Advisor.
+                            advisorURI is a required field that provides the URL link to the Red Hat Lightspeed Advisor UI.
                             The link must be a valid HTTPS URL and the maximum length is 2048 characters.
                           maxLength: 2048
                           minLength: 1


### PR DESCRIPTION
Rename all "Insights Advisor" references in API field descriptions to "Red Hat Lightspeed Advisor" across operator/v1, insights/v1, insights/v1alpha1, and insights/v1alpha2 types. 
The generated swagger docs, CRD manifests, and OpenAPI specs were updated with `make update`.

Ref: https://redhat.atlassian.net/browse/HCCDOC-4522