### PR TITLE
DNM: test patch for inline review comments

### DIFF
--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -37,8 +37,16 @@ type Console struct {
 
 // ConsoleSpec is the specification of the desired behavior of the Console.
 type ConsoleSpec struct {
+	// authentication configures console authentication behavior.
+	// When omitted, default authentication settings are used.
 	// +optional
 	Authentication ConsoleAuthentication `json:"authentication"`
+
+	// externalSecretStore configures integration with an external secret store
+	// for console secret management. When omitted, no external secret store is configured.
+	// +optional
+	// +openshift:enable:FeatureGate=ExternalSecretStore
+	ExternalSecretStore ExternalSecretStoreConfig `json:"externalSecretStore,omitempty,omitzero"`
 }
 
 // ConsoleStatus defines the observed status of the Console.
@@ -78,4 +86,73 @@ type ConsoleAuthentication struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=`^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$`
 	LogoutRedirect string `json:"logoutRedirect,omitempty"`
+}
+
+// ExternalSecretStoreType defines the type of external secret store.
+// When set to Vault, HashiCorp Vault is used as the external secret store.
+// +kubebuilder:validation:Enum=Vault
+type ExternalSecretStoreType string
+
+// ExternalSecretStoreConfig defines the configuration for integration with an
+// external secret store.
+// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'Vault' ? has(self.vault) : !has(self.vault)",message="vault configuration is required when type is Vault, and forbidden otherwise"
+type ExternalSecretStoreConfig struct {
+	// type specifies the type of external secret store to use.
+	// Currently supported values:
+	// - Vault
+	// +required
+	Type ExternalSecretStoreType `json:"type"`
+
+	// vault contains the configuration for a HashiCorp Vault secret store.
+	// This field is required when type is Vault, and forbidden otherwise.
+	// +optional
+	Vault VaultSecretStoreConfig `json:"vault,omitempty,omitzero"`
+}
+
+// VaultSecretStoreConfig defines the configuration for HashiCorp Vault integration.
+type VaultSecretStoreConfig struct {
+	// serverAddress specifies the address of the Vault server.
+	// Must be a valid URL starting with https://.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	ServerAddress string `json:"serverAddress"`
+
+	// transitKeyName specifies the name of the transit encryption key in Vault.
+	// The name must not exceed 253 characters.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	TransitKeyName string `json:"transitKeyName"`
+
+	// transitMountPath specifies the mount path for the transit secrets engine.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	TransitMountPath string `json:"transitMountPath"`
+
+	// namespace specifies the Vault namespace to use.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
+	Namespace string `json:"namespace,omitempty"`
+
+	// caCertificate contains the PEM-encoded CA certificate for TLS verification
+	// of the Vault server connection.
+	// When omitted, the system's trusted CA certificates are used.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=65536
+	CACertificate string `json:"caCertificate,omitempty"`
+
+	// authSecret references a secret containing the authentication credentials
+	// for Vault. The secret must exist in the openshift-config namespace.
+	// +required
+	AuthSecret SecretNameReference `json:"authSecret"`
+
+	// refreshInterval specifies how often secrets are re-fetched from Vault,
+	// in seconds. The value must be between 30 and 3600.
+	// When omitted, the platform chooses a reasonable default.
+	// +optional
+	// +kubebuilder:validation:Minimum=30
+	// +kubebuilder:validation:Maximum=3600
+	RefreshInterval int32 `json:"refreshInterval,omitempty"`
 }

--- a/features/features.go
+++ b/features/features.go
@@ -1053,3 +1053,12 @@ var (
 					enable(inClusterProfile(SelfManaged), inDevPreviewNoUpgrade()).
 					mustRegister()
 )
+
+var (
+	FeatureGateExternalSecretStore = newFeatureGate("ExternalSecretStore").
+						reportProblemsToJiraComponent("Management-Console").
+						contactPerson("jhadvig").
+						productScope(ocpSpecific).
+						enable(inTechPreviewNoUpgrade()).
+						mustRegister()
+)


### PR DESCRIPTION
Do not merge — throwaway PR for testing CI inline comment posting.

Applies the kms-vault-config eval integration test patch to exercise the /api-review inline commenting flow.