### PR TITLE
OCPBUGS-94869: fix(crd): adjust storage settings for CRIOCredentialProviderConfig

### DIFF
--- a/config/v1/manual-override-crd-manifests/criocredentialproviderconfigs.config.openshift.io/CRIOCredentialProviderConfig.yaml
+++ b/config/v1/manual-override-crd-manifests/criocredentialproviderconfigs.config.openshift.io/CRIOCredentialProviderConfig.yaml
@@ -6,6 +6,8 @@ metadata:
   name: criocredentialproviderconfigs.config.openshift.io
 spec:
   versions:
+  - name: v1
+    storage: false
   - name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -198,6 +200,6 @@ spec:
             be 'cluster'
           rule: self.metadata.name == 'cluster'
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_criocredentialproviderconfigs.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_criocredentialproviderconfigs.crd.yaml
@@ -209,7 +209,7 @@ spec:
             be 'cluster'
           rule: self.metadata.name == 'cluster'
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v1alpha1
@@ -404,6 +404,6 @@ spec:
             be 'cluster'
           rule: self.metadata.name == 'cluster'
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_criocredentialproviderconfigs.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_criocredentialproviderconfigs.crd.yaml
@@ -209,7 +209,7 @@ spec:
             be 'cluster'
           rule: self.metadata.name == 'cluster'
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v1alpha1
@@ -404,6 +404,6 @@ spec:
             be 'cluster'
           rule: self.metadata.name == 'cluster'
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}


### PR DESCRIPTION
Fix:  https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-upgrade-rhcos9-techpreview/2071854856083083264
- openshift/api#2725 ([OCPNODE-4125: Introduce to v1 CRIOCredentialProviderConfig by QiWang19 · Pull Request #2725 · openshift/api](https://github.com/openshift/api/pull/2725) ) (merged June 25, commit c85beac32742) modified the payload CRD manifest (payload-manifests/crds/0000_10_config-operator_01_criocredentialproviderconfigs.crd.yaml) to:
Add v1 with storage: true
Change v1alpha1 from storage: true to storage: false.

Although once all consumers migrate to v1, v1alpha1 goes away completely, during migration, we need to keep storage version as v1alpha1 for the CI to pass.
