### PR TITLE
OPRUN-4691: Promote OLMLifecycleAndCompatibility feature gate to Default

### DIFF
--- a/features.md
+++ b/features.md
@@ -26,7 +26,6 @@
 | NewOLMOwnSingleNamespace| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMPreflightPermissionChecks| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NoRegistryClusterInstall| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
-| OLMLifecycleAndCompatibility| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | ProvisioningRequestAvailable| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AWSDedicatedHosts| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
@@ -83,6 +82,7 @@
 | NewOLMWebhookProviderOpenshiftServiceCA| | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | NoOverlayMode| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | NutanixMultiSubnets| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| OLMLifecycleAndCompatibility| | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | OVNObservability| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | OnPremDNSRecords| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | SELinuxMount| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -477,7 +477,7 @@ var (
 						contactPerson("joelanford").
 						productScope(ocpSpecific).
 						enhancementPR("https://github.com/openshift/enhancements/pull/1991").
-						enable(inClusterProfile(SelfManaged), inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
+						enable(inDefault(), inOKD(), inClusterProfile(SelfManaged), inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
 						mustRegister()
 
 	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
@@ -249,9 +249,6 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
-                        "name": "OLMLifecycleAndCompatibility"
-                    },
-                    {
                         "name": "OVNObservability"
                     },
                     {
@@ -354,6 +351,9 @@
                     },
                     {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
+                    },
+                    {
+                        "name": "OLMLifecycleAndCompatibility"
                     },
                     {
                         "name": "OSStreams"

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
@@ -251,9 +251,6 @@
                         "name": "NutanixMultiSubnets"
                     },
                     {
-                        "name": "OLMLifecycleAndCompatibility"
-                    },
-                    {
                         "name": "OVNObservability"
                     },
                     {
@@ -356,6 +353,9 @@
                     },
                     {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
+                    },
+                    {
+                        "name": "OLMLifecycleAndCompatibility"
                     },
                     {
                         "name": "OSStreams"


### PR DESCRIPTION
## Summary
- Enables the `OLMLifecycleAndCompatibility` feature gate in the Default feature set for SelfManaged clusters
- Previously this gate was only enabled in TechPreviewNoUpgrade and DevPreviewNoUpgrade
- Updates `features/features.go`, generated feature gate manifests, and `features.md`

## 5 test rule exception request

We are requesting an exception to the 5-`It`-block requirement for this test suite. The test covers five distinct scenarios but structures them as `g.By` steps within a single `It` block. The reason is architectural, not a coverage shortcut.

**Scenarios covered**

1. Valid schema + package → returns the expected custom schema FBC blobs (multiple results, correct schema/package/name fields)
2. Valid schema + nonexistent package → returns empty stream
3. Nonexistent schema → returns empty stream
4. Valid schema + empty package → returns packageless (global) custom schema blobs
5. Missing `x-acknowledge-experimental` header → returns empty stream (experimental API contract enforced)

**Why a single `It` block**

Meaningful functional coverage of this endpoint requires a catalog with known, controlled content. An existing cluster catalog cannot substitute: once this feature ships to Default, real catalogs will contain lifecycle data, making any query result non-deterministic and unassertable.

Building that controlled catalog image in-cluster via a `BuildConfig` takes approximately 22 seconds. Splitting into five `It` blocks would trigger a separate image build per test because:

- Tests run in parallel across nodes
- `BeforeEach` runs independently per node, so shared setup is not possible
- `BeforeAll` is not an option: in Ginkgo's parallel runner it executes once per process, not once globally — with N parallel nodes we get N image builds

The single `It` builds the image once, creates one `CatalogSource`, opens one port-forward, and exercises all five scenarios against the same running pod. Coverage is equivalent to five separate tests.

The only genuinely parallelizable addition would be an input-validation test sending syntactically invalid schema/package names against an existing catalog pod (the rejection occurs before catalog lookup and is deterministic regardless of catalog content). That path is already covered by unit tests in operator-registry, so we have not duplicated it here at the E2E layer.

## Test plan
- [ ] Verify `make verify` passes
- [ ] Confirm feature gate is listed as enabled in Default for SelfManaged in `features.md`
- [ ] Validate generated payload manifests reflect the promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)