### PR TITLE
Sippy timestamp filter should use Millisecond unix timestamp for proper filtering

### DIFF
--- a/tools/codegen/pkg/sippy/json_types.go
+++ b/tools/codegen/pkg/sippy/json_types.go
@@ -337,7 +337,7 @@ func BuildSippyJobRunsForJobURL(release, jobName string, timestamp time.Time) st
 		{
 			ColumnField:   "timestamp",
 			OperatorValue: ">=",
-			Value:         fmt.Sprintf("%d", timestamp.Unix()),
+			Value:         fmt.Sprintf("%d", timestamp.UnixMilli()),
 		},
 	}
 


### PR DESCRIPTION
The sippy API expects a millisecond timestamp to ensure proper filtering. Tested locally I can see that with this fix it was showing around 30 runs in the past two weeks for the AWS dual stack job which tallies with what sippy reports

CC @everettraven 