### PR TITLE
OPRUN-4705: Remove NewOLMPreflightPermissionChecks FeatureGate

### DIFF
--- a/features.md
+++ b/features.md
@@ -26,7 +26,6 @@
 | NewOLMCatalogdAPIV1Metas| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMConfigAPI| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMOwnSingleNamespace| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
-| NewOLMPreflightPermissionChecks| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NoRegistryClusterInstall| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | ProvisioningRequestAvailable| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -424,14 +424,6 @@ var (
 						enable(inClusterProfile(SelfManaged), inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
 						mustRegister()
 
-	FeatureGateNewOLMPreflightPermissionChecks = newFeatureGate("NewOLMPreflightPermissionChecks").
-							reportProblemsToJiraComponent("olm").
-							contactPerson("tshort").
-							productScope(ocpSpecific).
-							enhancementPR("https://github.com/openshift/enhancements/pull/1768").
-							enable(inClusterProfile(SelfManaged), inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
-							mustRegister()
-
 	FeatureGateNewOLMOwnSingleNamespace = newFeatureGate("NewOLMOwnSingleNamespace").
 						reportProblemsToJiraComponent("olm").
 						contactPerson("nschieder").

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
@@ -243,9 +243,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
@@ -68,9 +68,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
@@ -245,9 +245,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
@@ -95,9 +95,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
@@ -243,9 +243,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NoOverlayMode"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -313,9 +313,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
@@ -245,9 +245,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NoOverlayMode"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -316,9 +316,6 @@
                         "name": "NewOLMOwnSingleNamespace"
                     },
                     {
-                        "name": "NewOLMPreflightPermissionChecks"
-                    },
-                    {
                         "name": "NewOLMWebhookProviderOpenshiftServiceCA"
                     },
                     {


### PR DESCRIPTION
## Summary

- Remove the `FeatureGateNewOLMPreflightPermissionChecks` definition from `features/features.go`
- Regenerate `features.md` and all `payload-manifests/featuregates/` YAML files

## Context

The upstream `PreflightPermissions` feature gate was removed from operator-controller ([operator-framework/operator-controller#767](https://github.com/openshift/operator-framework-operator-controller/pull/767)) and the downstream mapping was removed from cluster-olm-operator ([cluster-olm-operator#222](https://github.com/openshift/cluster-olm-operator/pull/222)). The gate definition in `openshift/api` is now dead weight — it is listed as enabled in TechPreview/DevPreview profiles but nothing acts on it.
