### PR TITLE
config/v1: add IBMCloudServiceTransitGateway and IBMCloudServicePowerVS to IBMCloudServiceName

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1369,7 +1369,7 @@ tests:
                 url: https://dummy.vpc.com
               - name: BadService
                 url: https://bad-service.com
-      expectedStatusError: 'platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: "BadService": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "ResourceController", "ResourceManager", "VPC"'
+      expectedStatusError: 'platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: "BadService": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "ResourceController", "ResourceManager", "VPC", "TransitGateway", "PowerVS"'
     - name: Should allow updating other fields with an invalid persisted PowerVS service endpoint name in spec
       initialCRDPatches:
         - op: replace
@@ -1477,7 +1477,7 @@ tests:
               serviceEndpoints:
               - name: dnsservices2
                 url: https://abc
-      expectedError: 'spec.platformSpec.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC"'
+      expectedError: 'spec.platformSpec.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC", "TransitGateway"'
     - name: Should allow updating adding updating an invalid value to a valid value for PowerVS service endpoint name in spec
       initialCRDPatches:
         - op: replace
@@ -1636,7 +1636,7 @@ tests:
               serviceEndpoints:
               - name: dnsservices2
                 url: https://abc
-      expectedStatusError: 'status.platformStatus.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC"'
+      expectedStatusError: 'status.platformStatus.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC", "TransitGateway"'
     - name: Should allow updating adding updating an invalid value to a valid value for PowerVS service endpoint name in status
       initialCRDPatches:
         - op: replace

--- a/config/v1/tests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -89,7 +89,7 @@ tests:
             serviceEndpoints:
             - name: InvalidService
               url: https://dummy.vpc.com/v1
-    expectedError: "spec.platformSpec.ibmcloud.serviceEndpoints[0].name: Unsupported value: \"InvalidService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
+    expectedError: "spec.platformSpec.ibmcloud.serviceEndpoints[0].name: Unsupported value: \"InvalidService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\", \"TransitGateway\", \"PowerVS\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
   - name: Should be able to add valid ServiceEndpoints to IBMCloud PlatformSpec
     initial: |
       apiVersion: config.openshift.io/v1

--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -403,7 +403,7 @@ const (
 
 // IBMCloudServiceName contains a value specifying the name of an IBM Cloud Service,
 // which are used by MAPI, CIRO, CIO, Installer, etc.
-// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;ResourceController;ResourceManager;VPC
+// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;ResourceController;ResourceManager;VPC;TransitGateway;PowerVS
 type IBMCloudServiceName string
 
 const (
@@ -433,4 +433,8 @@ const (
 	IBMCloudServiceResourceManager IBMCloudServiceName = "ResourceManager"
 	// IBMCloudServiceVPC is the name for IBM Cloud VPC.
 	IBMCloudServiceVPC IBMCloudServiceName = "VPC"
+	// IBMCloudServiceTransitGateway is the name for IBM Cloud Transit Gateway.
+	IBMCloudServiceTransitGateway IBMCloudServiceName = "TransitGateway"
+	// IBMCloudServicePowerVS is the name for IBM Cloud Power Virtual Server.
+	IBMCloudServicePowerVS IBMCloudServiceName = "PowerVS"
 )

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -1880,7 +1880,7 @@ type VSpherePlatformStatus struct {
 // override existing defaults of IBM Cloud Services.
 type IBMCloudServiceEndpoint struct {
 	// name is the name of the IBM Cloud service.
-	// Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+	// Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
 	// For example, the IBM Cloud Private IAM service could be configured with the
 	// service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
 	// Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1912,8 +1912,8 @@ type IBMCloudPlatformSpec struct {
 	// overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
 	// endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
 	// are updated to reflect the same custom endpoints.
-	// A maximum of 13 service endpoints overrides are supported.
-	// +kubebuilder:validation:MaxItems=13
+	// A maximum of 15 service endpoints overrides are supported.
+	// +kubebuilder:validation:MaxItems=15
 	// +listType=map
 	// +listMapKey=name
 	// +optional
@@ -1946,7 +1946,7 @@ type IBMCloudPlatformStatus struct {
 	// overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
 	// endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
 	// are updated to reflect the same custom endpoints.
-	// +openshift:validation:FeatureGateAwareMaxItems:featureGate=DyanmicServiceEndpointIBMCloud,maxItems=13
+	// +openshift:validation:FeatureGateAwareMaxItems:featureGate=DyanmicServiceEndpointIBMCloud,maxItems=15
 	// +listType=map
 	// +listMapKey=name
 	// +optional
@@ -1997,7 +1997,7 @@ type PowerVSServiceEndpoint struct {
 	// Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
 	//
 	// +required
-	// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;Power;ResourceController;ResourceManager;VPC
+	// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;Power;ResourceController;ResourceManager;VPC;TransitGateway
 	Name string `json:"name"`
 
 	// url is fully qualified URI with scheme https, that overrides the default generated

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2000,7 +2001,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2019,6 +2020,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2406,6 +2409,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
@@ -246,7 +246,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -255,7 +255,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -274,6 +274,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -294,7 +296,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -617,6 +619,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2170,7 +2173,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2189,6 +2192,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2205,7 +2210,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2646,6 +2651,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -231,7 +231,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -240,7 +240,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -259,6 +259,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -279,7 +281,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -602,6 +604,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2155,7 +2158,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2174,6 +2177,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2190,7 +2195,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2631,6 +2636,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2000,7 +2001,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2019,6 +2020,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2406,6 +2409,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -246,7 +246,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -255,7 +255,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -274,6 +274,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -294,7 +296,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -617,6 +619,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2170,7 +2173,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2189,6 +2192,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2205,7 +2210,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2646,6 +2651,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -246,7 +246,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -255,7 +255,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -274,6 +274,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -294,7 +296,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -617,6 +619,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2170,7 +2173,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2189,6 +2192,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2205,7 +2210,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2646,6 +2651,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2137,7 +2140,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2156,6 +2159,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2172,7 +2177,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2613,6 +2618,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1851,7 +1852,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1870,6 +1871,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2257,6 +2260,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNSInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNSInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1941,7 +1942,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1960,6 +1961,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2347,6 +2350,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSDualStackInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSDualStackInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1861,7 +1862,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1880,6 +1881,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2267,6 +2270,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureDualStackInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureDualStackInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1852,7 +1853,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1871,6 +1872,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2258,6 +2261,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BGPBasedVIPManagement.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BGPBasedVIPManagement.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1856,7 +1857,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1875,6 +1876,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2262,6 +2265,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1843,7 +1844,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1862,6 +1863,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2249,6 +2252,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -598,6 +600,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1899,7 +1902,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1918,6 +1921,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -1938,7 +1943,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2310,6 +2315,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPSovereignCloudInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPSovereignCloudInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1859,7 +1860,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1878,6 +1879,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2265,6 +2268,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/MutableTopology.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/MutableTopology.yaml
@@ -551,6 +551,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1852,7 +1853,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1871,6 +1872,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2258,6 +2261,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -541,6 +541,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1842,7 +1843,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1861,6 +1862,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2248,6 +2251,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/OnPremDNSRecords.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/OnPremDNSRecords.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1860,7 +1861,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1879,6 +1880,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2335,6 +2338,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1848,7 +1849,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1867,6 +1868,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2254,6 +2257,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1838,7 +1839,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1857,6 +1858,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2244,6 +2247,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenterDay2.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenterDay2.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1852,7 +1853,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1871,6 +1872,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2258,6 +2261,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1818,7 +1818,7 @@ func (GCPResourceTag) SwaggerDoc() map[string]string {
 
 var map_IBMCloudPlatformSpec = map[string]string{
 	"":                 "IBMCloudPlatformSpec holds the desired state of the IBMCloud infrastructure provider. This only includes fields that can be modified in the cluster.",
-	"serviceEndpoints": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 13 service endpoints overrides are supported.",
+	"serviceEndpoints": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 15 service endpoints overrides are supported.",
 }
 
 func (IBMCloudPlatformSpec) SwaggerDoc() map[string]string {
@@ -1841,7 +1841,7 @@ func (IBMCloudPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_IBMCloudServiceEndpoint = map[string]string{
 	"":     "IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.",
-	"name": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+	"name": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
 	"url":  "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty. The path must follow the pattern /v[0,9]+ or /api/v[0,9]+",
 }
 

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2301,7 +2302,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2320,6 +2321,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2708,6 +2711,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
@@ -545,7 +545,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -554,7 +554,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -573,6 +573,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -594,7 +596,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -925,6 +927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2487,7 +2490,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2506,6 +2509,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2522,7 +2527,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2967,6 +2972,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -530,7 +530,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -539,7 +539,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -558,6 +558,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -579,7 +581,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -910,6 +912,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2472,7 +2475,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2491,6 +2494,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2507,7 +2512,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2952,6 +2957,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2301,7 +2302,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2320,6 +2321,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2708,6 +2711,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -545,7 +545,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -554,7 +554,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -573,6 +573,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -594,7 +596,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -925,6 +927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2487,7 +2490,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2506,6 +2509,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2522,7 +2527,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2967,6 +2972,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -545,7 +545,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -554,7 +554,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -573,6 +573,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -594,7 +596,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -925,6 +927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2487,7 +2490,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2506,6 +2509,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2522,7 +2527,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2967,6 +2972,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2442,7 +2445,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2461,6 +2464,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2477,7 +2482,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2922,6 +2927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2163,7 +2164,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2182,6 +2183,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2570,6 +2573,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNSInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNSInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2247,7 +2248,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2266,6 +2267,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2654,6 +2657,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSDualStackInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSDualStackInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2167,7 +2168,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2186,6 +2187,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2574,6 +2577,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
@@ -830,6 +830,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2147,7 +2148,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2166,6 +2167,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2554,6 +2557,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureDualStackInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureDualStackInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2158,7 +2159,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2177,6 +2178,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2565,6 +2568,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BGPBasedVIPManagement.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BGPBasedVIPManagement.yaml
@@ -838,6 +838,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2174,7 +2175,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2193,6 +2194,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2581,6 +2584,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2149,7 +2150,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2168,6 +2169,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2556,6 +2559,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -515,7 +515,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -524,7 +524,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -543,6 +543,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -564,7 +566,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -889,6 +891,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2206,7 +2209,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2225,6 +2228,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2246,7 +2251,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2619,6 +2624,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPSovereignCloudInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPSovereignCloudInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2165,7 +2166,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2184,6 +2185,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2572,6 +2575,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/MutableTopology.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/MutableTopology.yaml
@@ -841,6 +841,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2158,7 +2159,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2177,6 +2178,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2565,6 +2568,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -832,6 +832,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2149,7 +2150,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2168,6 +2169,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2556,6 +2559,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/OnPremDNSRecords.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/OnPremDNSRecords.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2167,7 +2168,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2186,6 +2187,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2646,6 +2649,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2156,7 +2157,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2175,6 +2176,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2563,6 +2566,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2144,7 +2145,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2163,6 +2164,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2551,6 +2554,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenterDay2.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenterDay2.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2160,7 +2161,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2179,6 +2180,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2567,6 +2570,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -14821,7 +14821,7 @@ func schema_openshift_api_config_v1_IBMCloudPlatformSpec(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 13 service endpoints overrides are supported.",
+							Description: "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 15 service endpoints overrides are supported.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -14922,7 +14922,7 @@ func schema_openshift_api_config_v1_IBMCloudServiceEndpoint(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+							Description: "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -7666,7 +7666,7 @@
       "type": "object",
       "properties": {
         "serviceEndpoints": {
-          "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 13 service endpoints overrides are supported.",
+          "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 15 service endpoints overrides are supported.",
           "type": "array",
           "items": {
             "default": {},
@@ -7726,7 +7726,7 @@
       ],
       "properties": {
         "name": {
-          "description": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+          "description": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
           "type": "string",
           "default": ""
         },

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2000,7 +2001,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2019,6 +2020,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2406,6 +2409,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-CustomNoUpgrade.crd.yaml
@@ -246,7 +246,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -255,7 +255,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -274,6 +274,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -294,7 +296,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -617,6 +619,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2170,7 +2173,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2189,6 +2192,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2205,7 +2210,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2646,6 +2651,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -231,7 +231,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -240,7 +240,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -259,6 +259,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -279,7 +281,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -602,6 +604,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2155,7 +2158,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2174,6 +2177,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2190,7 +2195,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2631,6 +2636,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2000,7 +2001,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2019,6 +2020,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2406,6 +2409,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -246,7 +246,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -255,7 +255,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -274,6 +274,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -294,7 +296,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -617,6 +619,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2170,7 +2173,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2189,6 +2192,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2205,7 +2210,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2646,6 +2651,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -246,7 +246,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -255,7 +255,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -274,6 +274,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -294,7 +296,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -617,6 +619,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2170,7 +2173,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2189,6 +2192,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2205,7 +2210,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2646,6 +2651,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2137,7 +2140,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2156,6 +2159,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2172,7 +2177,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2613,6 +2618,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2301,7 +2302,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2320,6 +2321,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2708,6 +2711,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-CustomNoUpgrade.crd.yaml
@@ -545,7 +545,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -554,7 +554,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -573,6 +573,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -594,7 +596,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -925,6 +927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2487,7 +2490,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2506,6 +2509,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2522,7 +2527,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2967,6 +2972,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -530,7 +530,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -539,7 +539,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -558,6 +558,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -579,7 +581,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -910,6 +912,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2472,7 +2475,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2491,6 +2494,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2507,7 +2512,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2952,6 +2957,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2301,7 +2302,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2320,6 +2321,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2708,6 +2711,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -545,7 +545,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -554,7 +554,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -573,6 +573,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -594,7 +596,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -925,6 +927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2487,7 +2490,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2506,6 +2509,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2522,7 +2527,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2967,6 +2972,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -545,7 +545,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -554,7 +554,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -573,6 +573,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -594,7 +596,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -925,6 +927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2487,7 +2490,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2506,6 +2509,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2522,7 +2527,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2967,6 +2972,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2442,7 +2445,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2461,6 +2464,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2477,7 +2482,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2922,6 +2927,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-


### PR DESCRIPTION
Add TransitGateway and PowerVS to the IBMCloudServiceName enum so that users can override the IBM Cloud Transit Gateway and Power Virtual Server service endpoints via serviceEndpoints in the install-config (needed for Staging OpenShift install).

Both services are already supported by the IBM Cloud CAPI provider (sigs.k8s.io/cluster-api-provider-ibmcloud) which accepts transitgateway and powervs as valid service IDs in its --service-endpoint flag. The installer translates IBMCloudServiceName values to CAPI's internal service IDs in GetRegionAndEndpointsFlag(). Until these constants exist in openshift/api, the installer is forced to match against raw string literals with a workaround comment — this PR removes that need.

Changes:
Add ;TransitGateway;PowerVS to the +kubebuilder:validation:Enum marker on IBMCloudServiceName
Add IBMCloudServiceTransitGateway and IBMCloudServicePowerVS constants