### PR TITLE
 4.22 backport: add IBMCloudServiceTransitGateway and IBMCloudServicePowerVS to IBMCloudServiceName

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -2,7 +2,8 @@ apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if w
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
 featureGates:
-- -AWSClusterHostedDNSInstall
+  - -AWSClusterHostedDNS
+  - -VSphereMultiVCenterDay2
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure
@@ -45,7 +46,7 @@ tests:
             baremetal:
               apiServerInternalIPs:
                 - not-an-ip-address
-      expectedError: "spec.platformSpec.baremetal.apiServerInternalIPs[0]: Invalid value: \"string\": value must be a valid IP address"
+      expectedError: 'spec.platformSpec.baremetal.apiServerInternalIPs[0]: Invalid value: "string": value must be a valid IP address'
     - name: Should not be able to pass 2 IPv4 addresses to apiServerInternalIPs in the platform spec
       initial: |
         apiVersion: config.openshift.io/v1
@@ -114,7 +115,7 @@ tests:
             baremetal:
               ingressIPs:
                 - not-an-ip-address
-      expectedError: "spec.platformSpec.baremetal.ingressIPs[0]: Invalid value: \"string\": value must be a valid IP address"
+      expectedError: 'spec.platformSpec.baremetal.ingressIPs[0]: Invalid value: "string": value must be a valid IP address'
     - name: Should not be able to pass 2 IPv4 addresses to ingressIPs in the platform spec
       initial: |
         apiVersion: config.openshift.io/v1
@@ -183,7 +184,7 @@ tests:
             baremetal:
               machineNetworks:
                 - 192.0.2.1
-      expectedError: "spec.platformSpec.baremetal.machineNetworks[0]: Invalid value: \"string\": value must be a valid CIDR network address"
+      expectedError: 'spec.platformSpec.baremetal.machineNetworks[0]: Invalid value: "string": value must be a valid CIDR network address'
   onUpdate:
     - name: Should be able to change External platformName from unknown to something else
       initial: |
@@ -227,7 +228,7 @@ tests:
             type: External
             external:
               platformName: SomeOtherCoolplatformName
-      expectedError: " spec.platformSpec.external.platformName: Invalid value: \"string\": platform name cannot be changed once set"
+      expectedError: ' spec.platformSpec.external.platformName: Invalid value: "string": platform name cannot be changed once set'
     - name: Should not be able to modify an existing Azure ResourceTags Tag
       initial: |
         apiVersion: config.openshift.io/v1
@@ -253,7 +254,7 @@ tests:
             azure:
               resourceTags:
                 - {key: "key", value: "changed"}
-      expectedStatusError: "status.platformStatus.azure.resourceTags: Invalid value: \"array\": resourceTags are immutable and may only be configured during installation"
+      expectedStatusError: 'status.platformStatus.azure.resourceTags: Invalid value: "array": resourceTags are immutable and may only be configured during installation'
     - name: Should not be able to add a Tag to an existing Azure ResourceTags
       initial: |
         apiVersion: config.openshift.io/v1
@@ -280,7 +281,7 @@ tests:
               resourceTags:
                 - {key: "key", value: "value"}
                 - {key: "new", value: "entry"}
-      expectedStatusError: "status.platformStatus.azure.resourceTags: Invalid value: \"array\": resourceTags are immutable and may only be configured during installation"
+      expectedStatusError: 'status.platformStatus.azure.resourceTags: Invalid value: "array": resourceTags are immutable and may only be configured during installation'
     - name: Should not be able to remove a Tag from an existing Azure ResourceTags
       initial: |
         apiVersion: config.openshift.io/v1
@@ -305,7 +306,7 @@ tests:
             azure:
               resourceTags:
                 - {key: "key", value: "value"}
-      expectedStatusError: "status.platformStatus.azure.resourceTags: Invalid value: \"array\": resourceTags are immutable and may only be configured during installation"
+      expectedStatusError: 'status.platformStatus.azure.resourceTags: Invalid value: "array": resourceTags are immutable and may only be configured during installation'
     - name: Should not be able to add Azure ResourceTags to an empty platformStatus.azure
       initial: |
         apiVersion: config.openshift.io/v1
@@ -326,7 +327,7 @@ tests:
             azure:
               resourceTags:
                 - {key: "key", value: "value"}
-      expectedStatusError: "status.platformStatus.azure: Invalid value: \"object\": resourceTags may only be configured during installation"
+      expectedStatusError: 'status.platformStatus.azure: Invalid value: "object": resourceTags may only be configured during installation'
     - name: Should not be able to remove Azure ResourceTags from platformStatus.azure
       initial: |
         apiVersion: config.openshift.io/v1
@@ -348,7 +349,7 @@ tests:
           platformStatus:
             type: Azure
             azure: {}
-      expectedStatusError: "status.platformStatus.azure: Invalid value: \"object\": resourceTags may only be configured during installation"
+      expectedStatusError: 'status.platformStatus.azure: Invalid value: "object": resourceTags may only be configured during installation'
     - name: Should be able to modify the ResourceGroupName while Azure ResourceTags are present
       initial: |
         apiVersion: config.openshift.io/v1
@@ -460,7 +461,7 @@ tests:
           platformStatus:
             powervs:
               resourceGroup: other-resource-group-name
-      expectedStatusError: "status.platformStatus.powervs.resourceGroup: Invalid value: \"string\": resourceGroup is immutable once set"
+      expectedStatusError: 'status.platformStatus.powervs.resourceGroup: Invalid value: "string": resourceGroup is immutable once set'
     - name: Should not be able to unset PowerVS platform status's resourceGroup once it was set
       initial: |
         apiVersion: config.openshift.io/v1
@@ -485,7 +486,7 @@ tests:
           platformStatus:
             powervs:
               region: some-region
-      expectedStatusError: "status.platformStatus.powervs: Invalid value: \"object\": cannot unset resourceGroup once set"
+      expectedStatusError: 'status.platformStatus.powervs: Invalid value: "object": cannot unset resourceGroup once set'
     - name: Should set load balancer type to OpenShiftManagedDefault if not specified
       initial: |
         apiVersion: config.openshift.io/v1
@@ -634,7 +635,7 @@ tests:
               loadBalancer:
                 type: UserManaged
             type: BareMetal
-      expectedStatusError: "status.platformStatus.baremetal.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+      expectedStatusError: 'status.platformStatus.baremetal.loadBalancer.type: Invalid value: "string": type is immutable once set'
     - name: Should not allow changing the immutable OpenStack load balancer type field
       initial: |
         apiVersion: config.openshift.io/v1
@@ -668,7 +669,7 @@ tests:
               loadBalancer:
                 type: UserManaged
             type: OpenStack
-      expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+      expectedStatusError: 'status.platformStatus.openstack.loadBalancer.type: Invalid value: "string": type is immutable once set'
     - name: Should not allow removing the immutable OpenStack load balancer type field that was initially set
       initial: |
         apiVersion: config.openshift.io/v1
@@ -700,7 +701,7 @@ tests:
           platformStatus:
             openstack: {}
             type: OpenStack
-      expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+      expectedStatusError: 'status.platformStatus.openstack.loadBalancer.type: Invalid value: "string": type is immutable once set'
     - name: Should not allow removing the immutable BareMetal load balancer type field that was initially set
       initial: |
         apiVersion: config.openshift.io/v1
@@ -732,7 +733,7 @@ tests:
           platformStatus:
             baremetal: {}
             type: BareMetal
-      expectedStatusError: "status.platformStatus.baremetal.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+      expectedStatusError: 'status.platformStatus.baremetal.loadBalancer.type: Invalid value: "string": type is immutable once set'
     - name: Should not allow setting the load balancer type to a wrong value
       initial: |
         apiVersion: config.openshift.io/v1
@@ -755,7 +756,7 @@ tests:
               loadBalancer:
                 type: FooBar
             type: OpenStack
-      expectedStatusError: "platformStatus.openstack.loadBalancer.type: Unsupported value: \"FooBar\": supported values: \"OpenShiftManagedDefault\", \"UserManaged\""
+      expectedStatusError: 'platformStatus.openstack.loadBalancer.type: Unsupported value: "FooBar": supported values: "OpenShiftManagedDefault", "UserManaged"'
     - name: Should not be able to update cloudControllerManager state to empty string when state is already set to None
       initial: |
         apiVersion: config.openshift.io/v1
@@ -777,7 +778,7 @@ tests:
             external:
               cloudControllerManager:
                 state: ""
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager.state: Invalid value: \"string\": state is immutable once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager.state: Invalid value: "string": state is immutable once set'
     - name: Should not be able to update cloudControllerManager state to External when state is already set to None
       initial: |
         apiVersion: config.openshift.io/v1
@@ -801,7 +802,7 @@ tests:
             external:
               cloudControllerManager:
                 state: External
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager.state: Invalid value: \"string\": state is immutable once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager.state: Invalid value: "string": state is immutable once set'
     - name: Should be able to update cloudControllerManager state to None when state is already set to None
       initial: |
         apiVersion: config.openshift.io/v1
@@ -861,7 +862,7 @@ tests:
             type: External
             external:
               cloudControllerManager: {}
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager: Invalid value: \"object\": state may not be added or removed once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager: Invalid value: "object": state may not be added or removed once set'
     - name: Should not be able to update cloudControllerManager state to empty string when state is already set to External
       initial: |
         apiVersion: config.openshift.io/v1
@@ -885,7 +886,7 @@ tests:
             external:
               cloudControllerManager:
                 state: ""
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager.state: Invalid value: \"string\": state is immutable once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager.state: Invalid value: "string": state is immutable once set'
     - name: Should not be able to update cloudControllerManager state to None when state is already set to External
       initial: |
         apiVersion: config.openshift.io/v1
@@ -909,7 +910,7 @@ tests:
             external:
               cloudControllerManager:
                 state: None
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager.state: Invalid value: \"string\": state is immutable once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager.state: Invalid value: "string": state is immutable once set'
     - name: Should be able to update cloudControllerManager state to External when state is already set to External
       initial: |
         apiVersion: config.openshift.io/v1
@@ -969,7 +970,7 @@ tests:
             type: External
             external:
               cloudControllerManager: {}
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager: Invalid value: \"object\": state may not be added or removed once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager: Invalid value: "object": state may not be added or removed once set'
     - name: Should not be able to update cloudControllerManager state to None when state is already set to empty string
       initial: |
         apiVersion: config.openshift.io/v1
@@ -993,7 +994,7 @@ tests:
             external:
               cloudControllerManager:
                 state: None
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager.state: Invalid value: \"string\": state is immutable once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager.state: Invalid value: "string": state is immutable once set'
     - name: Should not be able to update cloudControllerManager state to External when state is already set to empty string
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1017,7 +1018,7 @@ tests:
             external:
               cloudControllerManager:
                 state: External
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager.state: Invalid value: \"string\": state is immutable once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager.state: Invalid value: "string": state is immutable once set'
     - name: Should be able to update cloudControllerManager state to empty string when state is already set to empty string
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1077,7 +1078,7 @@ tests:
             type: External
             external:
               cloudControllerManager: {}
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager: Invalid value: \"object\": state may not be added or removed once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager: Invalid value: "object": state may not be added or removed once set'
     - name: Should be able to update cloudControllerManager state to None when cloudControllerManager state is unset
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1172,7 +1173,7 @@ tests:
             external:
               cloudControllerManager:
                 state: External
-      expectedStatusError: " status.platformStatus.external.cloudControllerManager: Invalid value: \"object\": state may not be added or removed once set"
+      expectedStatusError: ' status.platformStatus.external.cloudControllerManager: Invalid value: "object": state may not be added or removed once set'
     - name: Should be able to unset cloudControllerManager state when cloudControllerManager state is unset
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1228,7 +1229,7 @@ tests:
             external:
               cloudControllerManager:
                 state: External
-      expectedStatusError: " status.platformStatus.external: Invalid value: \"object\": cloudControllerManager may not be added or removed once set"
+      expectedStatusError: ' status.platformStatus.external: Invalid value: "object": cloudControllerManager may not be added or removed once set'
     - name: Should not be able to remove cloudControllerManager when cloudControllerManager is set
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1250,7 +1251,7 @@ tests:
           platformStatus:
             type: External
             external: {}
-      expectedStatusError: " status.platformStatus.external: Invalid value: \"object\": cloudControllerManager may not be added or removed once set"
+      expectedStatusError: ' status.platformStatus.external: Invalid value: "object": cloudControllerManager may not be added or removed once set'
     - name: Should be able to add valid (URL) ServiceEndpoints to IBMCloud PlatformStatus
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1316,7 +1317,7 @@ tests:
               serviceEndpoints:
               - name: COS
                 url: " "
-      expectedStatusError: "status.platformStatus.ibmcloud.serviceEndpoints[0].url: Invalid value: \"string\": url must be a valid absolute URL"
+      expectedStatusError: 'status.platformStatus.ibmcloud.serviceEndpoints[0].url: Invalid value: "string": url must be a valid absolute URL'
     - name: Should not be able to add invalid (URL) ServiceEndpoints to IBMCloud PlatformStatus
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1342,7 +1343,7 @@ tests:
                 url: https://dummy.vpc.com
               - name: COS
                 url: dummy-cos-com
-      expectedStatusError: "platformStatus.ibmcloud.serviceEndpoints[1].url: Invalid value: \"string\": url must be a valid absolute URL"
+      expectedStatusError: 'platformStatus.ibmcloud.serviceEndpoints[1].url: Invalid value: "string": url must be a valid absolute URL'
     - name: Should not be able to add invalid (Name) ServiceEndpoints to IBMCloud PlatformStatus
       initial: |
         apiVersion: config.openshift.io/v1
@@ -1368,14 +1369,14 @@ tests:
                 url: https://dummy.vpc.com
               - name: BadService
                 url: https://bad-service.com
-      expectedStatusError: "platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: \"BadService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\""
+      expectedStatusError: 'platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: "BadService": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "ResourceController", "ResourceManager", "VPC", "TransitGateway", "PowerVS"'
     - name: Should allow updating other fields with an invalid persisted PowerVS service endpoint name in spec
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1410,11 +1411,11 @@ tests:
                 url: https://abc
     - name: Should allow updating adding another slice entry with an invalid persisted PowerVS service endpoint name in spec
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1451,11 +1452,11 @@ tests:
                 url: https://abc
     - name: Should not allow updating adding an invalid value to a still invalid value for a PowerVS service endpoint name in spec
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1476,14 +1477,14 @@ tests:
               serviceEndpoints:
               - name: dnsservices2
                 url: https://abc
-      expectedError: 'spec.platformSpec.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC"'
+      expectedError: 'spec.platformSpec.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC", "TransitGateway"'
     - name: Should allow updating adding updating an invalid value to a valid value for PowerVS service endpoint name in spec
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1516,11 +1517,11 @@ tests:
                 url: https://abc
     - name: Should allow updating other fields with an invalid persisted PowerVS service endpoint name in status
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1561,11 +1562,11 @@ tests:
                 url: https://abc
     - name: Should allow updating adding another slice entry with an invalid persisted PowerVS service endpoint name in status
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1608,11 +1609,11 @@ tests:
                 url: https://abc
     - name: Should not allow updating adding an invalid value to a still invalid value for a PowerVS service endpoint name in status
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1635,14 +1636,14 @@ tests:
               serviceEndpoints:
               - name: dnsservices2
                 url: https://abc
-      expectedStatusError: 'status.platformStatus.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC"'
+      expectedStatusError: 'status.platformStatus.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC", "TransitGateway"'
     - name: Should allow updating adding updating an invalid value to a valid value for PowerVS service endpoint name in status
       initialCRDPatches:
-      - op: replace
-        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
-        value:
-          pattern: "^[a-z0-9-]+$"
-          type: string
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+          value:
+            pattern: "^[a-z0-9-]+$"
+            type: string
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -1732,6 +1733,8 @@ tests:
           platform: AWS
           platformStatus:
             aws:
+              cloudLoadBalancerConfig:
+                dnsType: PlatformDefault
               region: us-east-1
               resourceTags:
               - key: key with space
@@ -1778,6 +1781,8 @@ tests:
           platform: AWS
           platformStatus:
             aws:
+              cloudLoadBalancerConfig:
+                dnsType: PlatformDefault
               region: us-east-1
               resourceTags:
               - key: key:_./=+-@
@@ -1839,3 +1844,137 @@ tests:
                 value: value*
             type: AWS
       expectedStatusError: "invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
+    - name: Should allow updating other fields with an invalid persisted vcenters array (empty) in spec
+      initialCRDPatches:
+        - op: remove
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/vsphere/properties/vcenters/minItems
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          cloudConfig:
+            key: config
+            name: cloud-provider-config
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          cloudConfig:
+            key: config
+            name: cloud-provider-config
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+    - name: Should allow keeping an invalid persisted vcenters array (empty) in spec unchanged
+      initialCRDPatches:
+        - op: remove
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/vsphere/properties/vcenters/minItems
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+              failureDomains:
+              - name: fd1
+                region: region1
+                server: vcenter1.example.com
+                topology:
+                  computeCluster: /DC1/host/cluster1
+                  datacenter: DC1
+                  datastore: /DC1/datastore/ds1
+                  networks:
+                  - network1
+                  resourcePool: /DC1/host/cluster1/Resources
+                zone: zone1
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+              failureDomains:
+              - name: fd1
+                region: region1
+                server: vcenter1.example.com
+                topology:
+                  computeCluster: /DC1/host/cluster1
+                  datacenter: DC1
+                  datastore: /DC1/datastore/ds1
+                  networks:
+                  - network1
+                  resourcePool: /DC1/host/cluster1/Resources
+                zone: zone1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+              failureDomains:
+              - name: fd1
+                region: region1
+                server: vcenter1.example.com
+                topology:
+                  computeCluster: /DC1/host/cluster1
+                  datacenter: DC1
+                  datastore: /DC1/datastore/ds1
+                  networks:
+                  - network1
+                  resourcePool: /DC1/host/cluster1/Resources
+                zone: zone1
+    - name: Should allow updating an invalid persisted vcenters array (empty) to a valid value (1 vcenter) in spec
+      initialCRDPatches:
+        - op: remove
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/vsphere/properties/vcenters/minItems
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters: []
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters:
+              - server: vcenter1.example.com
+                port: 443
+                datacenters:
+                - DC1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: VSphere
+            vsphere:
+              vcenters:
+              - server: vcenter1.example.com
+                port: 443
+                datacenters:
+                - DC1

--- a/config/v1/tests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -89,7 +89,7 @@ tests:
             serviceEndpoints:
             - name: InvalidService
               url: https://dummy.vpc.com/v1
-    expectedError: "spec.platformSpec.ibmcloud.serviceEndpoints[0].name: Unsupported value: \"InvalidService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
+    expectedError: "spec.platformSpec.ibmcloud.serviceEndpoints[0].name: Unsupported value: \"InvalidService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\", \"TransitGateway\", \"PowerVS\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
   - name: Should be able to add valid ServiceEndpoints to IBMCloud PlatformSpec
     initial: |
       apiVersion: config.openshift.io/v1

--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -403,7 +403,7 @@ const (
 
 // IBMCloudServiceName contains a value specifying the name of an IBM Cloud Service,
 // which are used by MAPI, CIRO, CIO, Installer, etc.
-// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;ResourceController;ResourceManager;VPC
+// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;ResourceController;ResourceManager;VPC;TransitGateway;PowerVS
 type IBMCloudServiceName string
 
 const (
@@ -433,4 +433,8 @@ const (
 	IBMCloudServiceResourceManager IBMCloudServiceName = "ResourceManager"
 	// IBMCloudServiceVPC is the name for IBM Cloud VPC.
 	IBMCloudServiceVPC IBMCloudServiceName = "VPC"
+	// IBMCloudServiceTransitGateway is the name for IBM Cloud Transit Gateway.
+	IBMCloudServiceTransitGateway IBMCloudServiceName = "TransitGateway"
+	// IBMCloudServicePowerVS is the name for IBM Cloud Power Virtual Server.
+	IBMCloudServicePowerVS IBMCloudServiceName = "PowerVS"
 )

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -1798,7 +1798,7 @@ type VSpherePlatformStatus struct {
 // override existing defaults of IBM Cloud Services.
 type IBMCloudServiceEndpoint struct {
 	// name is the name of the IBM Cloud service.
-	// Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+	// Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
 	// For example, the IBM Cloud Private IAM service could be configured with the
 	// service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
 	// Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1830,8 +1830,8 @@ type IBMCloudPlatformSpec struct {
 	// overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
 	// endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
 	// are updated to reflect the same custom endpoints.
-	// A maximum of 13 service endpoints overrides are supported.
-	// +kubebuilder:validation:MaxItems=13
+	// A maximum of 15 service endpoints overrides are supported.
+	// +kubebuilder:validation:MaxItems=15
 	// +listType=map
 	// +listMapKey=name
 	// +optional
@@ -1864,7 +1864,7 @@ type IBMCloudPlatformStatus struct {
 	// overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
 	// endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
 	// are updated to reflect the same custom endpoints.
-	// +openshift:validation:FeatureGateAwareMaxItems:featureGate=DyanmicServiceEndpointIBMCloud,maxItems=13
+	// +openshift:validation:FeatureGateAwareMaxItems:featureGate=DyanmicServiceEndpointIBMCloud,maxItems=15
 	// +listType=map
 	// +listMapKey=name
 	// +optional
@@ -1915,7 +1915,7 @@ type PowerVSServiceEndpoint struct {
 	// Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
 	//
 	// +required
-	// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;Power;ResourceController;ResourceManager;VPC
+	// +kubebuilder:validation:Enum=CIS;COS;COSConfig;DNSServices;GlobalCatalog;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;Power;ResourceController;ResourceManager;VPC;TransitGateway
 	Name string `json:"name"`
 
 	// url is fully qualified URI with scheme https, that overrides the default generated

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2094,7 +2097,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2113,6 +2116,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2129,7 +2134,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2570,6 +2575,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1871,7 +1872,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1890,6 +1891,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2277,6 +2280,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2094,7 +2097,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2113,6 +2116,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2129,7 +2134,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2570,6 +2575,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1871,7 +1872,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1890,6 +1891,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2277,6 +2280,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2094,7 +2097,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2113,6 +2116,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2129,7 +2134,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2570,6 +2575,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1744,7 +1745,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1763,6 +1764,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2150,6 +2153,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNSInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNSInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1841,7 +1842,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1860,6 +1861,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2247,6 +2250,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSDualStackInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSDualStackInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1752,7 +1753,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1771,6 +1772,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2158,6 +2161,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureClusterHostedDNSInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureClusterHostedDNSInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1840,7 +1841,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1859,6 +1860,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2246,6 +2249,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureDualStackInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AzureDualStackInstall.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1752,7 +1753,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1771,6 +1772,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2158,6 +2161,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1743,7 +1744,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1762,6 +1763,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2149,6 +2152,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -598,6 +600,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1799,7 +1802,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1818,6 +1821,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -1838,7 +1843,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2210,6 +2215,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -541,6 +541,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1742,7 +1743,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1761,6 +1762,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2148,6 +2151,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/OnPremDNSRecords.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/OnPremDNSRecords.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1760,7 +1761,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1779,6 +1780,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2235,6 +2238,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1748,7 +1749,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1767,6 +1768,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2154,6 +2157,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -536,6 +536,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1738,7 +1739,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1757,6 +1758,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2144,6 +2147,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1685,7 +1685,7 @@ func (GCPResourceTag) SwaggerDoc() map[string]string {
 
 var map_IBMCloudPlatformSpec = map[string]string{
 	"":                 "IBMCloudPlatformSpec holds the desired state of the IBMCloud infrastructure provider. This only includes fields that can be modified in the cluster.",
-	"serviceEndpoints": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 13 service endpoints overrides are supported.",
+	"serviceEndpoints": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 15 service endpoints overrides are supported.",
 }
 
 func (IBMCloudPlatformSpec) SwaggerDoc() map[string]string {
@@ -1708,7 +1708,7 @@ func (IBMCloudPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_IBMCloudServiceEndpoint = map[string]string{
 	"":     "IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.",
-	"name": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+	"name": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
 	"url":  "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty. The path must follow the pattern /v[0,9]+ or /api/v[0,9]+",
 }
 

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2399,7 +2402,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2418,6 +2421,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2434,7 +2439,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2879,6 +2884,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2173,7 +2174,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2192,6 +2193,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2580,6 +2583,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2399,7 +2402,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2418,6 +2421,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2434,7 +2439,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2879,6 +2884,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2173,7 +2174,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2192,6 +2193,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2580,6 +2583,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2399,7 +2402,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2418,6 +2421,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2434,7 +2439,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2879,6 +2884,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2056,7 +2057,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2075,6 +2076,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2463,6 +2466,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNSInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNSInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2149,7 +2150,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2168,6 +2169,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2556,6 +2559,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSDualStackInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSDualStackInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2060,7 +2061,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2079,6 +2080,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2467,6 +2470,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSEuropeanSovereignCloudInstall.yaml
@@ -830,6 +830,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2049,7 +2050,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2068,6 +2069,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2456,6 +2459,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureClusterHostedDNSInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureClusterHostedDNSInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2148,7 +2149,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2167,6 +2168,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2555,6 +2558,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureDualStackInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AzureDualStackInstall.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2060,7 +2061,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2079,6 +2080,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2467,6 +2470,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DualReplica.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2051,7 +2052,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2070,6 +2071,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2458,6 +2461,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/DyanmicServiceEndpointIBMCloud.yaml
@@ -515,7 +515,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -524,7 +524,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -543,6 +543,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -564,7 +566,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -889,6 +891,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2108,7 +2111,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2127,6 +2130,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2148,7 +2153,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2521,6 +2526,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -832,6 +832,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2051,7 +2052,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2070,6 +2071,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2458,6 +2461,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/OnPremDNSRecords.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/OnPremDNSRecords.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2069,7 +2070,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2088,6 +2089,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2548,6 +2551,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2058,7 +2059,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2077,6 +2078,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2465,6 +2468,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -826,6 +826,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2046,7 +2047,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2065,6 +2066,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2453,6 +2456,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -14226,7 +14226,7 @@ func schema_openshift_api_config_v1_IBMCloudPlatformSpec(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 13 service endpoints overrides are supported.",
+							Description: "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 15 service endpoints overrides are supported.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -14327,7 +14327,7 @@ func schema_openshift_api_config_v1_IBMCloudServiceEndpoint(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+							Description: "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -18920,7 +18920,7 @@
       "type": "object",
       "properties": {
         "serviceEndpoints": {
-          "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 13 service endpoints overrides are supported.",
+          "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM service. These endpoints are used by components within the cluster when trying to reach the IBM Cloud Services that have been overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus are updated to reflect the same custom endpoints. A maximum of 15 service endpoints overrides are supported.",
           "type": "array",
           "items": {
             "default": {},
@@ -18980,7 +18980,7 @@
       ],
       "properties": {
         "name": {
-          "description": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+          "description": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
           "type": "string",
           "default": ""
         },

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2094,7 +2097,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2113,6 +2116,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2129,7 +2134,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2570,6 +2575,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1871,7 +1872,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1890,6 +1891,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2277,6 +2280,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2094,7 +2097,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2113,6 +2116,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2129,7 +2134,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2570,6 +2575,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-OKD.crd.yaml
@@ -537,6 +537,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -1871,7 +1872,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -1890,6 +1891,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2277,6 +2280,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -232,7 +232,7 @@ spec:
                           overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                           endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                           are updated to reflect the same custom endpoints.
-                          A maximum of 13 service endpoints overrides are supported.
+                          A maximum of 15 service endpoints overrides are supported.
                         items:
                           description: |-
                             IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -241,7 +241,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -260,6 +260,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -280,7 +282,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -603,6 +605,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-
@@ -2094,7 +2097,7 @@ spec:
                             name:
                               description: |-
                                 name is the name of the IBM Cloud service.
-                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                 For example, the IBM Cloud Private IAM service could be configured with the
                                 service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                 Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2113,6 +2116,8 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
+                              - PowerVS
                               type: string
                             url:
                               description: |-
@@ -2129,7 +2134,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 13
+                        maxItems: 15
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -2570,6 +2575,7 @@ spec:
                               - ResourceController
                               - ResourceManager
                               - VPC
+                              - TransitGateway
                               type: string
                             url:
                               description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2399,7 +2402,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2418,6 +2421,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2434,7 +2439,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2879,6 +2884,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2173,7 +2174,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2192,6 +2193,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2580,6 +2583,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2399,7 +2402,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2418,6 +2421,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2434,7 +2439,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2879,6 +2884,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-OKD.crd.yaml
@@ -831,6 +831,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2173,7 +2174,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2192,6 +2193,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2580,6 +2583,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -519,7 +519,7 @@ spec:
                                   overridden. The CCCMO reads in the IBMCloudPlatformSpec and validates each
                                   endpoint is resolvable. Once validated, the cloud config and IBMCloudPlatformStatus
                                   are updated to reflect the same custom endpoints.
-                                  A maximum of 13 service endpoints overrides are supported.
+                                  A maximum of 15 service endpoints overrides are supported.
                                 items:
                                   description: |-
                                     IBMCloudServiceEndpoint stores the configuration of a custom url to
@@ -528,7 +528,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -547,6 +547,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -568,7 +570,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -899,6 +901,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-
@@ -2399,7 +2402,7 @@ spec:
                                     name:
                                       description: |-
                                         name is the name of the IBM Cloud service.
-                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
+                                        Possible values are: CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, VPC, TransitGateway, or PowerVS.
                                         For example, the IBM Cloud Private IAM service could be configured with the
                                         service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
                                         Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
@@ -2418,6 +2421,8 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
+                                      - PowerVS
                                       type: string
                                     url:
                                       description: |-
@@ -2434,7 +2439,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 13
+                                maxItems: 15
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name
@@ -2879,6 +2884,7 @@ spec:
                                       - ResourceController
                                       - ResourceManager
                                       - VPC
+                                      - TransitGateway
                                       type: string
                                     url:
                                       description: |-


### PR DESCRIPTION
Add TransitGateway and PowerVS to the IBMCloudServiceName enum so that users can override the IBM Cloud Transit Gateway and Power Virtual Server service endpoints via serviceEndpoints in the install-config (needed for Staging OpenShift install).

Both services are already supported by the IBM Cloud CAPI provider (sigs.k8s.io/cluster-api-provider-ibmcloud) which accepts transitgateway and powervs as valid service IDs in its --service-endpoint flag. The installer translates IBMCloudServiceName values to CAPI's internal service IDs in GetRegionAndEndpointsFlag(). Until these constants exist in openshift/api, the installer is forced to match against raw string literals with a workaround comment — this PR removes that need.

Changes:
Add ;TransitGateway;PowerVS to the +kubebuilder:validation:Enum marker on IBMCloudServiceName
Add IBMCloudServiceTransitGateway and IBMCloudServicePowerVS constants