### PR TITLE
Use regex instead of format help for KMS secret name validation

### DIFF
--- a/config/v1/tests/ingresses.config.openshift.io/IngressComponentRouteLabels.yaml
+++ b/config/v1/tests/ingresses.config.openshift.io/IngressComponentRouteLabels.yaml
@@ -230,7 +230,7 @@ tests:
               hostname: console.example.com
               labels:
                 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: value
-      expectedError: "label keys must be valid qualified names, consisting of an optional DNS subdomain prefix"
+      expectedError: "label keys must be between 1 and 63 characters in length"
     - name: Should reject componentRoutes with label value starting with dash
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -1087,7 +1087,7 @@ type SourceURL struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=259
 	// +kubebuilder:validation:XValidation:rule="isURL('https://'+self)",message="hostname must be a valid hostname"
-	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self.split(':')[0]).hasValue()",message="hostname before port must start and end with a lowercase alphanumeric character, and must only contain lowercase alphanumeric characters, '-' or '.'"
+	// +kubebuilder:validation:XValidation:rule="self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')",message="hostname before port must start and end with a lowercase alphanumeric character, and must only contain lowercase alphanumeric characters, '-' or '.'"
 	// +kubebuilder:validation:XValidation:rule="self.split(':').size() > 1 ? int(self.split(':')[1]) <= 65535 : true",message="port must not exceed 65535"
 	Hostname string `json:"hostname,omitempty"`
 
@@ -1194,7 +1194,7 @@ type ExternalSourceCertificateAuthorityConfigMapReference struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="name must start and end with a lowercase alphanumeric character, and must only contain lowercase alphanumeric characters, '-' or '.'"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')",message="name must start and end with a lowercase alphanumeric character, and must only contain lowercase alphanumeric characters, '-' or '.'"
 	Name string `json:"name,omitempty"`
 }
 
@@ -1211,6 +1211,6 @@ type ClientSecretSecretReference struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="name must start and end with a lowercase alphanumeric character, and must only contain lowercase alphanumeric characters, '-' or '.'"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')",message="name must start and end with a lowercase alphanumeric character, and must only contain lowercase alphanumeric characters, '-' or '.'"
 	Name string `json:"name,omitempty"`
 }

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -171,7 +171,8 @@ const (
 // alphanumeric characters, '-', '_', or '.', starting and ending with
 // an alphanumeric character.
 // +kubebuilder:validation:MaxLength=63
-// +kubebuilder:validation:XValidation:rule="!format.labelValue().validate(self).hasValue()",message="label values must be valid Kubernetes label values (at most 63 characters, alphanumeric, '-', '_', or '.', must start and end with alphanumeric)"
+// +kubebuilder:validation:MinLength=0
+// +kubebuilder:validation:XValidation:rule="self == \"\" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')",message="label values must be valid Kubernetes label values (at most 63 characters, alphanumeric, '-', '_', or '.', must start and end with alphanumeric)"
 type LabelValue string
 
 // ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
@@ -278,7 +279,8 @@ type ComponentRouteSpec struct {
 	// +mapType=granular
 	// +kubebuilder:validation:MinProperties=1
 	// +kubebuilder:validation:MaxProperties=8
-	// +kubebuilder:validation:XValidation:rule="self.all(key, !format.qualifiedName().validate(key).hasValue())",message="label keys must be valid qualified names, consisting of an optional DNS subdomain prefix of up to 253 characters followed by a slash and a name segment of 1-63 characters, that consists only of alphanumeric characters, dashes, underscores, and dots, and must start and end with an alphanumeric character"
+	// +kubebuilder:validation:XValidation:rule="self.all(key, key.size() <= 63 && key.size() > 0)",message="label keys must be between 1 and 63 characters in length"
+	// +kubebuilder:validation:XValidation:rule="self.all(key, key.matches('^([a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?)*\\\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$') && key.size() <= 253)",message="label keys must be valid qualified names, consisting of an optional DNS subdomain prefix of up to 253 characters followed by a slash and a name segment of 1-63 characters, that consists only of alphanumeric characters, dashes, underscores, and dots, and must start and end with an alphanumeric character"
 	// +kubebuilder:validation:XValidation:rule="self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/') && !key.startsWith('openshift.io/'))",message="kubernetes.io/, k8s.io/, and openshift.io/ prefixed label keys are reserved and may not be used"
 	Labels map[string]LabelValue `json:"labels,omitempty"`
 }

--- a/config/v1/types_kmsencryption.go
+++ b/config/v1/types_kmsencryption.go
@@ -63,7 +63,7 @@ type VaultSecretReference struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="name must be a valid DNS subdomain name: contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?)*$')",message="name must be a valid DNS subdomain name: contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character"
 	// +required
 	Name string `json:"name,omitempty"`
 }
@@ -76,7 +76,7 @@ type VaultConfigMapReference struct {
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="name must be a valid DNS subdomain name: contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?)*$')",message="name must be a valid DNS subdomain name: contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character"
 	// +required
 	Name string `json:"name,omitempty"`
 }
@@ -300,7 +300,7 @@ type VaultTLSConfig struct {
 	//
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="serverName must be a valid DNS hostname: contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?(\\\\.[a-z0-9]([a-z0-9\\\\-]*[a-z0-9])?)*$')",message="serverName must be a valid DNS hostname: contain no more than 253 characters, contain only lowercase alphanumeric characters, '-' or '.', and start and end with an alphanumeric character"
 	// +optional
 	ServerName string `json:"serverName,omitempty"`
 }

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-CustomNoUpgrade.crd.yaml
@@ -518,7 +518,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -583,7 +583,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -791,7 +791,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -827,7 +827,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-DevPreviewNoUpgrade.crd.yaml
@@ -518,7 +518,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -583,7 +583,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -791,7 +791,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -827,7 +827,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-TechPreviewNoUpgrade.crd.yaml
@@ -518,7 +518,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -583,7 +583,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -791,7 +791,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -827,7 +827,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses-CustomNoUpgrade.crd.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses-DevPreviewNoUpgrade.crd.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses-TechPreviewNoUpgrade.crd.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')

--- a/config/v1/zz_generated.featuregated-crd-manifests/apiservers.config.openshift.io/KMSEncryption.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/apiservers.config.openshift.io/KMSEncryption.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDCExternalClaimsSourcing.yaml
@@ -306,7 +306,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -371,7 +371,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -579,7 +579,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -615,7 +615,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/IngressComponentRouteLabels.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/IngressComponentRouteLabels.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers-CustomNoUpgrade.crd.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers-DevPreviewNoUpgrade.crd.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers-TechPreviewNoUpgrade.crd.yaml
@@ -212,7 +212,7 @@ spec:
                                             contain only lowercase alphanumeric characters,
                                             ''-'' or ''.'', and start and end with
                                             an alphanumeric character'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -307,7 +307,7 @@ spec:
                                         contain only lowercase alphanumeric characters,
                                         ''-'' or ''.'', and start and end with an
                                         alphanumeric character'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -327,7 +327,7 @@ spec:
                                     contain no more than 253 characters, contain only
                                     lowercase alphanumeric characters, ''-'' or ''.'',
                                     and start and end with an alphanumeric character'
-                                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                  rule: self.matches('^[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*$')
                             type: object
                           vaultAddress:
                             description: |-

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-CustomNoUpgrade.crd.yaml
@@ -518,7 +518,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -583,7 +583,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -791,7 +791,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -827,7 +827,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-DevPreviewNoUpgrade.crd.yaml
@@ -518,7 +518,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -583,7 +583,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -791,7 +791,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -827,7 +827,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-TechPreviewNoUpgrade.crd.yaml
@@ -518,7 +518,7 @@ spec:
                                             lowercase alphanumeric character, and
                                             must only contain lowercase alphanumeric
                                             characters, '-' or '.'
-                                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                          rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                     required:
                                     - name
                                     type: object
@@ -583,7 +583,7 @@ spec:
                                                 a lowercase alphanumeric character,
                                                 and must only contain lowercase alphanumeric
                                                 characters, '-' or '.'
-                                              rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                              rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                         required:
                                         - name
                                         type: object
@@ -791,7 +791,7 @@ spec:
                                         alphanumeric character, and must only contain
                                         lowercase alphanumeric characters, '-' or
                                         '.'
-                                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                                      rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 required:
                                 - name
                                 type: object
@@ -827,7 +827,7 @@ spec:
                                     with a lowercase alphanumeric character, and must
                                     only contain lowercase alphanumeric characters,
                                     '-' or '.'
-                                  rule: '!format.dns1123Subdomain().validate(self.split('':'')[0]).hasValue()'
+                                  rule: self.split(':')[0].matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$')
                                 - message: port must not exceed 65535
                                   rule: 'self.split('':'').size() > 1 ? int(self.split('':'')[1])
                                     <= 65535 : true'

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses-CustomNoUpgrade.crd.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses-DevPreviewNoUpgrade.crd.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses-TechPreviewNoUpgrade.crd.yaml
@@ -85,12 +85,13 @@ spec:
                           alphanumeric characters, '-', '_', or '.', starting and ending with
                           an alphanumeric character.
                         maxLength: 63
+                        minLength: 0
                         type: string
                         x-kubernetes-validations:
                         - message: label values must be valid Kubernetes label values
                             (at most 63 characters, alphanumeric, '-', '_', or '.',
                             must start and end with alphanumeric)
-                          rule: '!format.labelValue().validate(self).hasValue()'
+                          rule: self == "" || self.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
                       description: |-
                         labels defines additional labels to be applied to the route created
                         for the component. These labels are used by the IngressController to
@@ -114,12 +115,16 @@ spec:
                       type: object
                       x-kubernetes-map-type: granular
                       x-kubernetes-validations:
+                      - message: label keys must be between 1 and 63 characters in
+                          length
+                        rule: self.all(key, key.size() <= 63 && key.size() > 0)
                       - message: label keys must be valid qualified names, consisting
                           of an optional DNS subdomain prefix of up to 253 characters
                           followed by a slash and a name segment of 1-63 characters,
                           that consists only of alphanumeric characters, dashes, underscores,
                           and dots, and must start and end with an alphanumeric character
-                        rule: self.all(key, !format.qualifiedName().validate(key).hasValue())
+                        rule: self.all(key, key.matches('^([a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)*\\/)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
+                          && key.size() <= 253)
                       - message: kubernetes.io/, k8s.io/, and openshift.io/ prefixed
                           label keys are reserved and may not be used
                         rule: self.all(key, !key.startsWith('kubernetes.io/') && !key.startsWith('k8s.io/')


### PR DESCRIPTION
The current validation using the format library is breaking HyperShift integration testing, this will be functionally equivalent but not rely on the library which came later

CC @ardaguclu 