### PR TITLE
Add printer columns to PodNetworkConnectivityCheck CRD

### DIFF
--- a/operatorcontrolplane/v1alpha1/types_conditioncheck.go
+++ b/operatorcontrolplane/v1alpha1/types_conditioncheck.go
@@ -15,6 +15,9 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=podnetworkconnectivitychecks,scope=Namespaced
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Target Endpoint",type=string,JSONPath=".spec.targetEndpoint",description="The endpoint being checked"
+// +kubebuilder:printcolumn:name="Reachable",type=string,JSONPath=".status.conditions[?(@.type==\"Reachable\")].status",description="Whether the target endpoint is reachable"
+// +kubebuilder:printcolumn:name="Since",type=date,JSONPath=".status.conditions[?(@.type==\"Reachable\")].lastTransitionTime",description="The time the reachability status last changed"
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/639
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=network,operatorOrdering=01
 // +kubebuilder:metadata:annotations=include.release.openshift.io/self-managed-high-availability=true

--- a/operatorcontrolplane/v1alpha1/types_conditioncheck.go
+++ b/operatorcontrolplane/v1alpha1/types_conditioncheck.go
@@ -18,6 +18,7 @@ import (
 // +kubebuilder:printcolumn:name="Target Endpoint",type=string,JSONPath=".spec.targetEndpoint",description="The endpoint being checked"
 // +kubebuilder:printcolumn:name="Reachable",type=string,JSONPath=".status.conditions[?(@.type==\"Reachable\")].status",description="Whether the target endpoint is reachable"
 // +kubebuilder:printcolumn:name="Since",type=date,JSONPath=".status.conditions[?(@.type==\"Reachable\")].lastTransitionTime",description="The time the reachability status last changed"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/639
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=network,operatorOrdering=01
 // +kubebuilder:metadata:annotations=include.release.openshift.io/self-managed-high-availability=true

--- a/operatorcontrolplane/v1alpha1/zz_generated.crd-manifests/0000_10_network_01_podnetworkconnectivitychecks.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/zz_generated.crd-manifests/0000_10_network_01_podnetworkconnectivitychecks.crd.yaml
@@ -15,7 +15,20 @@ spec:
     singular: podnetworkconnectivitycheck
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The endpoint being checked
+      jsonPath: .spec.targetEndpoint
+      name: Target Endpoint
+      type: string
+    - description: Whether the target endpoint is reachable
+      jsonPath: .status.conditions[?(@.type=="Reachable")].status
+      name: Reachable
+      type: string
+    - description: The time the reachability status last changed
+      jsonPath: .status.conditions[?(@.type=="Reachable")].lastTransitionTime
+      name: Since
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/operatorcontrolplane/v1alpha1/zz_generated.crd-manifests/0000_10_network_01_podnetworkconnectivitychecks.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/zz_generated.crd-manifests/0000_10_network_01_podnetworkconnectivitychecks.crd.yaml
@@ -28,6 +28,9 @@ spec:
       jsonPath: .status.conditions[?(@.type=="Reachable")].lastTransitionTime
       name: Since
       type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -14,7 +14,19 @@ podnetworkconnectivitychecks.controlplane.operator.openshift.io:
   KindName: PodNetworkConnectivityCheck
   Labels: {}
   PluralName: podnetworkconnectivitychecks
-  PrinterColumns: []
+  PrinterColumns:
+  - description: The endpoint being checked
+    jsonPath: .spec.targetEndpoint
+    name: Target Endpoint
+    type: string
+  - description: Whether the target endpoint is reachable
+    jsonPath: .status.conditions[?(@.type=="Reachable")].status
+    name: Reachable
+    type: string
+  - description: The time the reachability status last changed
+    jsonPath: .status.conditions[?(@.type=="Reachable")].lastTransitionTime
+    name: Since
+    type: date
   Scope: Namespaced
   ShortNames: null
   TopLevelFeatureGates: []

--- a/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -27,6 +27,9 @@ podnetworkconnectivitychecks.controlplane.operator.openshift.io:
     jsonPath: .status.conditions[?(@.type=="Reachable")].lastTransitionTime
     name: Since
     type: date
+  - jsonPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   Scope: Namespaced
   ShortNames: null
   TopLevelFeatureGates: []

--- a/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests/podnetworkconnectivitychecks.controlplane.operator.openshift.io/AAA_ungated.yaml
+++ b/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests/podnetworkconnectivitychecks.controlplane.operator.openshift.io/AAA_ungated.yaml
@@ -31,6 +31,9 @@ spec:
       jsonPath: .status.conditions[?(@.type=="Reachable")].lastTransitionTime
       name: Since
       type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests/podnetworkconnectivitychecks.controlplane.operator.openshift.io/AAA_ungated.yaml
+++ b/operatorcontrolplane/v1alpha1/zz_generated.featuregated-crd-manifests/podnetworkconnectivitychecks.controlplane.operator.openshift.io/AAA_ungated.yaml
@@ -18,7 +18,20 @@ spec:
     singular: podnetworkconnectivitycheck
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The endpoint being checked
+      jsonPath: .spec.targetEndpoint
+      name: Target Endpoint
+      type: string
+    - description: Whether the target endpoint is reachable
+      jsonPath: .status.conditions[?(@.type=="Reachable")].status
+      name: Reachable
+      type: string
+    - description: The time the reachability status last changed
+      jsonPath: .status.conditions[?(@.type=="Reachable")].lastTransitionTime
+      name: Since
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-


### PR DESCRIPTION
## Summary

- Adds `additionalPrinterColumns` to the `PodNetworkConnectivityCheck` CRD so that `oc get podnetworkconnectivitychecks` displays useful status information at a glance
- Adds three columns: **Target Endpoint**, **Reachable** (True/False), and **Since** (last transition time)
- Previously only NAME and AGE were shown, requiring YAML inspection or jsonpath queries to determine check results

Fixes: https://redhat.atlassian.net/browse/RFE-5093

## Before

```
NAMESPACE                       NAME                                                                AGE
openshift-network-diagnostics   network-check-source-...-to-kubernetes-apiserver-service-cluster    18d
openshift-network-diagnostics   network-check-source-...-to-load-balancer-api-external              18d
```

## After

```
NAMESPACE                       NAME                                                                TARGET ENDPOINT                                       REACHABLE   SINCE
openshift-network-diagnostics   network-check-source-...-to-kubernetes-apiserver-service-cluster    172.30.86.198:443                                     True        17d
openshift-network-diagnostics   network-check-source-...-to-load-balancer-api-external              api.swshende.vmware.gsslab.pnq2.redhat.com:6443       True        18d
openshift-network-diagnostics   network-check-source-...-to-network-check-target-service-cluster    network-check-target:80                               True        18d
```

## Implementation

Added 3 `+kubebuilder:printcolumn` annotations to `PodNetworkConnectivityCheck` type in `operatorcontrolplane/v1alpha1/types_conditioncheck.go`:

```go
// +kubebuilder:printcolumn:name="Target Endpoint",type=string,JSONPath=".spec.targetEndpoint",description="The endpoint being checked"
// +kubebuilder:printcolumn:name="Reachable",type=string,JSONPath=".status.conditions[?(@.type==\"Reachable\")].status",description="Whether the target endpoint is reachable"
// +kubebuilder:printcolumn:name="Since",type=date,JSONPath=".status.conditions[?(@.type==\"Reachable\")].lastTransitionTime",description="The time the reachability status last changed"
```

This follows the same pattern used by `ClusterOperator`, `ClusterVersion`, and `Route` CRDs.

## Test Plan

- [x] Applied updated CRD to live OCP 4.22.3 cluster
- [x] Verified `oc get podnetworkconnectivitychecks -A` shows all 3 new columns
- [x] Verified column values match underlying resource data
- [x] Verified `-o json` and `-o yaml` output unchanged
- [x] Verified `-o wide` works correctly
- [x] Verified all 18 resources render with correct data
- [x] Ran `make update` (with `PROTO_OPTIONAL=1`) — code generation passes


Made with [Cursor](https://cursor.com)