### PR TITLE
OCPBUGS-112330: Fix 'supercede' typos in machineconfiguration types

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -61579,7 +61579,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicySpecFile(ref common.Re
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -61614,7 +61614,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicySpecSSHKey(ref common.
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -61657,7 +61657,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicySpecUnit(ref common.Re
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -61769,7 +61769,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicyStatusFile(ref common.
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -61804,7 +61804,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicyStatusSSHKey(ref commo
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -61847,7 +61847,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicyStatusUnit(ref common.
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+							Description: "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -35783,7 +35783,7 @@
       ],
       "properties": {
         "actions": {
-          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
           "type": "array",
           "items": {
             "default": {},
@@ -35806,7 +35806,7 @@
       ],
       "properties": {
         "actions": {
-          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
           "type": "array",
           "items": {
             "default": {},
@@ -35825,7 +35825,7 @@
       ],
       "properties": {
         "actions": {
-          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
           "type": "array",
           "items": {
             "default": {},
@@ -35889,7 +35889,7 @@
       ],
       "properties": {
         "actions": {
-          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
           "type": "array",
           "items": {
             "default": {},
@@ -35912,7 +35912,7 @@
       ],
       "properties": {
         "actions": {
-          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
           "type": "array",
           "items": {
             "default": {},
@@ -35931,7 +35931,7 @@
       ],
       "properties": {
         "actions": {
-          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+          "description": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
           "type": "array",
           "items": {
             "default": {},

--- a/operator/v1/types_machineconfiguration.go
+++ b/operator/v1/types_machineconfiguration.go
@@ -508,7 +508,7 @@ type NodeDisruptionPolicySpecFile struct {
 	// actions represents the series of commands to be executed on changes to the file at
 	// the corresponding file path. Actions will be applied in the order that
 	// they are set in this list. If there are other incoming changes to other MachineConfig
-	// entries in the same update that require a reboot, the reboot will supercede these actions.
+	// entries in the same update that require a reboot, the reboot will supersede these actions.
 	// Valid actions are Reboot, Drain, Reload, DaemonReload and None.
 	// The Reboot action and the None action cannot be used in conjunction with any of the other actions.
 	// This list supports a maximum of 10 entries.
@@ -529,7 +529,7 @@ type NodeDisruptionPolicyStatusFile struct {
 	// actions represents the series of commands to be executed on changes to the file at
 	// the corresponding file path. Actions will be applied in the order that
 	// they are set in this list. If there are other incoming changes to other MachineConfig
-	// entries in the same update that require a reboot, the reboot will supercede these actions.
+	// entries in the same update that require a reboot, the reboot will supersede these actions.
 	// Valid actions are Reboot, Drain, Reload, DaemonReload and None.
 	// The Reboot action and the None action cannot be used in conjunction with any of the other actions.
 	// This list supports a maximum of 10 entries.
@@ -554,7 +554,7 @@ type NodeDisruptionPolicySpecUnit struct {
 	// actions represents the series of commands to be executed on changes to the file at
 	// the corresponding file path. Actions will be applied in the order that
 	// they are set in this list. If there are other incoming changes to other MachineConfig
-	// entries in the same update that require a reboot, the reboot will supercede these actions.
+	// entries in the same update that require a reboot, the reboot will supersede these actions.
 	// Valid actions are Reboot, Drain, Reload, DaemonReload and None.
 	// The Reboot action and the None action cannot be used in conjunction with any of the other actions.
 	// This list supports a maximum of 10 entries.
@@ -579,7 +579,7 @@ type NodeDisruptionPolicyStatusUnit struct {
 	// actions represents the series of commands to be executed on changes to the file at
 	// the corresponding file path. Actions will be applied in the order that
 	// they are set in this list. If there are other incoming changes to other MachineConfig
-	// entries in the same update that require a reboot, the reboot will supercede these actions.
+	// entries in the same update that require a reboot, the reboot will supersede these actions.
 	// Valid actions are Reboot, Drain, Reload, DaemonReload and None.
 	// The Reboot action and the None action cannot be used in conjunction with any of the other actions.
 	// This list supports a maximum of 10 entries.
@@ -596,7 +596,7 @@ type NodeDisruptionPolicySpecSSHKey struct {
 	// actions represents the series of commands to be executed on changes to the file at
 	// the corresponding file path. Actions will be applied in the order that
 	// they are set in this list. If there are other incoming changes to other MachineConfig
-	// entries in the same update that require a reboot, the reboot will supercede these actions.
+	// entries in the same update that require a reboot, the reboot will supersede these actions.
 	// Valid actions are Reboot, Drain, Reload, DaemonReload and None.
 	// The Reboot action and the None action cannot be used in conjunction with any of the other actions.
 	// This list supports a maximum of 10 entries.
@@ -613,7 +613,7 @@ type NodeDisruptionPolicyStatusSSHKey struct {
 	// actions represents the series of commands to be executed on changes to the file at
 	// the corresponding file path. Actions will be applied in the order that
 	// they are set in this list. If there are other incoming changes to other MachineConfig
-	// entries in the same update that require a reboot, the reboot will supercede these actions.
+	// entries in the same update that require a reboot, the reboot will supersede these actions.
 	// Valid actions are Reboot, Drain, Reload, DaemonReload and None.
 	// The Reboot action and the None action cannot be used in conjunction with any of the other actions.
 	// This list supports a maximum of 10 entries.

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations.crd.yaml
@@ -360,7 +360,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -486,7 +486,7 @@ spec:
                           actions represents the series of commands to be executed on changes to the file at
                           the corresponding file path. Actions will be applied in the order that
                           they are set in this list. If there are other incoming changes to other MachineConfig
-                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          entries in the same update that require a reboot, the reboot will supersede these actions.
                           Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                           The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                           This list supports a maximum of 10 entries.
@@ -605,7 +605,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -1129,7 +1129,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.
@@ -1254,7 +1254,7 @@ spec:
                               actions represents the series of commands to be executed on changes to the file at
                               the corresponding file path. Actions will be applied in the order that
                               they are set in this list. If there are other incoming changes to other MachineConfig
-                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              entries in the same update that require a reboot, the reboot will supersede these actions.
                               Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                               The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                               This list supports a maximum of 10 entries.
@@ -1373,7 +1373,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/AAA_ungated.yaml
@@ -230,7 +230,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -356,7 +356,7 @@ spec:
                           actions represents the series of commands to be executed on changes to the file at
                           the corresponding file path. Actions will be applied in the order that
                           they are set in this list. If there are other incoming changes to other MachineConfig
-                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          entries in the same update that require a reboot, the reboot will supersede these actions.
                           Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                           The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                           This list supports a maximum of 10 entries.
@@ -475,7 +475,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -859,7 +859,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.
@@ -984,7 +984,7 @@ spec:
                               actions represents the series of commands to be executed on changes to the file at
                               the corresponding file path. Actions will be applied in the order that
                               they are set in this list. If there are other incoming changes to other MachineConfig
-                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              entries in the same update that require a reboot, the reboot will supersede these actions.
                               Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                               The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                               This list supports a maximum of 10 entries.
@@ -1103,7 +1103,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/BootImageSkewEnforcement.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/BootImageSkewEnforcement.yaml
@@ -320,7 +320,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -446,7 +446,7 @@ spec:
                           actions represents the series of commands to be executed on changes to the file at
                           the corresponding file path. Actions will be applied in the order that
                           they are set in this list. If there are other incoming changes to other MachineConfig
-                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          entries in the same update that require a reboot, the reboot will supersede these actions.
                           Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                           The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                           This list supports a maximum of 10 entries.
@@ -565,7 +565,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -1081,7 +1081,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.
@@ -1206,7 +1206,7 @@ spec:
                               actions represents the series of commands to be executed on changes to the file at
                               the corresponding file path. Actions will be applied in the order that
                               they are set in this list. If there are other incoming changes to other MachineConfig
-                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              entries in the same update that require a reboot, the reboot will supersede these actions.
                               Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                               The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                               This list supports a maximum of 10 entries.
@@ -1325,7 +1325,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/IrreconcilableMachineConfig.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/IrreconcilableMachineConfig.yaml
@@ -261,7 +261,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -387,7 +387,7 @@ spec:
                           actions represents the series of commands to be executed on changes to the file at
                           the corresponding file path. Actions will be applied in the order that
                           they are set in this list. If there are other incoming changes to other MachineConfig
-                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          entries in the same update that require a reboot, the reboot will supersede these actions.
                           Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                           The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                           This list supports a maximum of 10 entries.
@@ -506,7 +506,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -888,7 +888,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.
@@ -1013,7 +1013,7 @@ spec:
                               actions represents the series of commands to be executed on changes to the file at
                               the corresponding file path. Actions will be applied in the order that
                               they are set in this list. If there are other incoming changes to other MachineConfig
-                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              entries in the same update that require a reboot, the reboot will supersede these actions.
                               Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                               The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                               This list supports a maximum of 10 entries.
@@ -1132,7 +1132,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/ManagedBootImagesCPMS.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/ManagedBootImagesCPMS.yaml
@@ -236,7 +236,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -362,7 +362,7 @@ spec:
                           actions represents the series of commands to be executed on changes to the file at
                           the corresponding file path. Actions will be applied in the order that
                           they are set in this list. If there are other incoming changes to other MachineConfig
-                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          entries in the same update that require a reboot, the reboot will supersede these actions.
                           Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                           The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                           This list supports a maximum of 10 entries.
@@ -481,7 +481,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -871,7 +871,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.
@@ -996,7 +996,7 @@ spec:
                               actions represents the series of commands to be executed on changes to the file at
                               the corresponding file path. Actions will be applied in the order that
                               they are set in this list. If there are other incoming changes to other MachineConfig
-                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              entries in the same update that require a reboot, the reboot will supersede these actions.
                               Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                               The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                               This list supports a maximum of 10 entries.
@@ -1115,7 +1115,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1685,7 +1685,7 @@ func (NodeDisruptionPolicySpecAction) SwaggerDoc() map[string]string {
 var map_NodeDisruptionPolicySpecFile = map[string]string{
 	"":        "NodeDisruptionPolicySpecFile is a file entry and corresponding actions to take and is used in the NodeDisruptionPolicyConfig object",
 	"path":    "path is the location of a file being managed through a MachineConfig. The Actions in the policy will apply to changes to the file at this path.",
-	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 }
 
 func (NodeDisruptionPolicySpecFile) SwaggerDoc() map[string]string {
@@ -1694,7 +1694,7 @@ func (NodeDisruptionPolicySpecFile) SwaggerDoc() map[string]string {
 
 var map_NodeDisruptionPolicySpecSSHKey = map[string]string{
 	"":        "NodeDisruptionPolicySpecSSHKey is actions to take for any SSHKey change and is used in the NodeDisruptionPolicyConfig object",
-	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 }
 
 func (NodeDisruptionPolicySpecSSHKey) SwaggerDoc() map[string]string {
@@ -1704,7 +1704,7 @@ func (NodeDisruptionPolicySpecSSHKey) SwaggerDoc() map[string]string {
 var map_NodeDisruptionPolicySpecUnit = map[string]string{
 	"":        "NodeDisruptionPolicySpecUnit is a systemd unit name and corresponding actions to take and is used in the NodeDisruptionPolicyConfig object",
 	"name":    "name represents the service name of a systemd service managed through a MachineConfig Actions specified will be applied for changes to the named service. Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long. ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, \":\", \"-\", \"_\", \".\", and \"\". ${SERVICETYPE} must be one of \".service\", \".socket\", \".device\", \".mount\", \".automount\", \".swap\", \".target\", \".path\", \".timer\", \".snapshot\", \".slice\" or \".scope\".",
-	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 }
 
 func (NodeDisruptionPolicySpecUnit) SwaggerDoc() map[string]string {
@@ -1732,7 +1732,7 @@ func (NodeDisruptionPolicyStatusAction) SwaggerDoc() map[string]string {
 var map_NodeDisruptionPolicyStatusFile = map[string]string{
 	"":        "NodeDisruptionPolicyStatusFile is a file entry and corresponding actions to take and is used in the NodeDisruptionPolicyClusterStatus object",
 	"path":    "path is the location of a file being managed through a MachineConfig. The Actions in the policy will apply to changes to the file at this path.",
-	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 }
 
 func (NodeDisruptionPolicyStatusFile) SwaggerDoc() map[string]string {
@@ -1741,7 +1741,7 @@ func (NodeDisruptionPolicyStatusFile) SwaggerDoc() map[string]string {
 
 var map_NodeDisruptionPolicyStatusSSHKey = map[string]string{
 	"":        "NodeDisruptionPolicyStatusSSHKey is actions to take for any SSHKey change and is used in the NodeDisruptionPolicyClusterStatus object",
-	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 }
 
 func (NodeDisruptionPolicyStatusSSHKey) SwaggerDoc() map[string]string {
@@ -1751,7 +1751,7 @@ func (NodeDisruptionPolicyStatusSSHKey) SwaggerDoc() map[string]string {
 var map_NodeDisruptionPolicyStatusUnit = map[string]string{
 	"":        "NodeDisruptionPolicyStatusUnit is a systemd unit name and corresponding actions to take and is used in the NodeDisruptionPolicyClusterStatus object",
 	"name":    "name represents the service name of a systemd service managed through a MachineConfig Actions specified will be applied for changes to the named service. Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long. ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, \":\", \"-\", \"_\", \".\", and \"\". ${SERVICETYPE} must be one of \".service\", \".socket\", \".device\", \".mount\", \".automount\", \".swap\", \".target\", \".path\", \".timer\", \".snapshot\", \".slice\" or \".scope\".",
-	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supercede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
+	"actions": "actions represents the series of commands to be executed on changes to the file at the corresponding file path. Actions will be applied in the order that they are set in this list. If there are other incoming changes to other MachineConfig entries in the same update that require a reboot, the reboot will supersede these actions. Valid actions are Reboot, Drain, Reload, DaemonReload and None. The Reboot action and the None action cannot be used in conjunction with any of the other actions. This list supports a maximum of 10 entries.",
 }
 
 func (NodeDisruptionPolicyStatusUnit) SwaggerDoc() map[string]string {

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations.crd.yaml
@@ -360,7 +360,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -486,7 +486,7 @@ spec:
                           actions represents the series of commands to be executed on changes to the file at
                           the corresponding file path. Actions will be applied in the order that
                           they are set in this list. If there are other incoming changes to other MachineConfig
-                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          entries in the same update that require a reboot, the reboot will supersede these actions.
                           Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                           The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                           This list supports a maximum of 10 entries.
@@ -605,7 +605,7 @@ spec:
                             actions represents the series of commands to be executed on changes to the file at
                             the corresponding file path. Actions will be applied in the order that
                             they are set in this list. If there are other incoming changes to other MachineConfig
-                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            entries in the same update that require a reboot, the reboot will supersede these actions.
                             Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                             The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                             This list supports a maximum of 10 entries.
@@ -1129,7 +1129,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.
@@ -1254,7 +1254,7 @@ spec:
                               actions represents the series of commands to be executed on changes to the file at
                               the corresponding file path. Actions will be applied in the order that
                               they are set in this list. If there are other incoming changes to other MachineConfig
-                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              entries in the same update that require a reboot, the reboot will supersede these actions.
                               Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                               The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                               This list supports a maximum of 10 entries.
@@ -1373,7 +1373,7 @@ spec:
                                 actions represents the series of commands to be executed on changes to the file at
                                 the corresponding file path. Actions will be applied in the order that
                                 they are set in this list. If there are other incoming changes to other MachineConfig
-                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                entries in the same update that require a reboot, the reboot will supersede these actions.
                                 Valid actions are Reboot, Drain, Reload, DaemonReload and None.
                                 The Reboot action and the None action cannot be used in conjunction with any of the other actions.
                                 This list supports a maximum of 10 entries.


### PR DESCRIPTION
Fixes OCPBUGS-112330

Correcting the grammatical spelling of 'supercede' to 'supersede' across docstrings and generated swagger documentation in machineconfiguration types.

Signed-off-by: Pratik Langde <plangde@redhat.com>