### PR TITLE
Add CapacityBuffer feature gate to TechPreview

### DIFF
--- a/features.md
+++ b/features.md
@@ -14,6 +14,7 @@
 | MutableTopology| | | | <span style="background-color: #519450">Enabled</span> | | | |  |
 | AuthenticationComponentProxy| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | BGPBasedVIPManagement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
+| CapacityBufferAvailable| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ClusterAPIComputeInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ClusterAPIControlPlaneInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ClusterUpdatePreflight| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |

--- a/features/features.go
+++ b/features/features.go
@@ -1067,4 +1067,11 @@ var (
 					enhancementPR("https://github.com/openshift/enhancements/pull/2047").
 					enable(inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
 					mustRegister()
+
+	FeatureGateCapacityBufferAvailable = newFeatureGate("CapacityBufferAvailable").
+						reportProblemsToJiraComponent("Cluster Autoscaler").
+						contactPerson("elmiko").
+						productScope(ocpSpecific).
+						enable(inTechPreviewNoUpgrade(), inDevPreviewNoUpgrade()).
+						mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-Default.yaml
@@ -54,6 +54,9 @@
                         "name": "CRIOCredentialProviderConfig"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-DevPreviewNoUpgrade.yaml
@@ -136,6 +136,9 @@
                         "name": "CRDCompatibilityRequirementOperator"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsPreferCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-OKD.yaml
@@ -56,6 +56,9 @@
                         "name": "CRIOCredentialProviderConfig"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-Hypershift-TechPreviewNoUpgrade.yaml
@@ -26,6 +26,9 @@
                         "name": "CRIOCredentialProviderConfig"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-Default.yaml
@@ -51,6 +51,9 @@
                         "name": "CRDCompatibilityRequirementOperator"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -109,6 +109,9 @@
                         "name": "CRIOCredentialProviderConfig"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsPreferCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-OKD.yaml
@@ -53,6 +53,9 @@
                         "name": "CRDCompatibilityRequirementOperator"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-4-10-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -20,6 +20,9 @@
                         "name": "BGPBasedVIPManagement"
                     },
                     {
+                        "name": "CapacityBufferAvailable"
+                    },
+                    {
                         "name": "ClientsAllowCBOR"
                     },
                     {


### PR DESCRIPTION
## Summary

Register the `CapacityBufferAvailable` feature gate and enable it under TechPreviewNoUpgrade and DevPreviewNoUpgrade feature sets.

## Details

This adds the CapacityBufferAvailable feature gate to OpenShift for the Cluster Autoscaler.

- **Feature gate**: `CapacityBufferAvailable`
- **Product scope**: ocpSpecific
- **Enabled in**: TechPreviewNoUpgrade, DevPreviewNoUpgrade

### Changed files

- `features/features.go` — feature gate definition
- `features.md` — documentation table update
- `payload-manifests/featuregates/featureGate-*.yaml` — generated manifest updates for all SelfManagedHA and Hypershift profiles

Companion PR: To be created