### PR TITLE
OCPBUGS-56908: validate identity provider names as annotation keys

### DIFF
--- a/config/v1/tests/oauths.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/oauths.config.openshift.io/AAA_ungated.yaml
@@ -12,3 +12,182 @@ tests:
         apiVersion: config.openshift.io/v1
         kind: OAuth
         spec: {}
+    - name: Should be able to create an identity provider with a valid annotation-key name
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+    - name: Should be able to create an identity provider named AIF-Keycloak
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: AIF-Keycloak
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: AIF-Keycloak
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+    - name: Should not be able to create an identity provider whose name contains spaces
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        metadata:
+          name: cluster
+        spec:
+          identityProviders:
+          - name: Microsoft Entra ID
+            mappingMethod: claim
+            type: OpenID
+            openID:
+              clientID: example
+              clientSecret:
+                name: microsoft-entra-id-secret
+              issuer: https://login.microsoftonline.com/example/v2.0
+      expectedError: "identity provider name must consist of alphanumeric characters"
+    - name: Should not be able to create an identity provider named AIF - Keycloak
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        metadata:
+          name: cluster
+        spec:
+          identityProviders:
+          - name: AIF - Keycloak
+            mappingMethod: claim
+            type: OpenID
+            openID:
+              clientID: example
+              clientSecret:
+                name: aif-keycloak-secret
+              issuer: https://keycloak.example.com/realms/example
+      expectedError: "identity provider name must consist of alphanumeric characters"
+  onUpdate:
+    - name: Should allow updating other fields of a valid identity provider
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret-updated
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret-updated
+    - name: Should not be able to add a new identity provider whose name contains spaces
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: htpasswd
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: htpasswd
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+          - name: AIF - Keycloak
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      expectedError: "identity provider name must consist of alphanumeric characters"
+    - name: Should allow renaming an identity provider to another valid annotation-key name
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: MicrosoftEntraID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        spec:
+          identityProviders:
+          - name: Microsoft-Entra-ID
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -38,6 +38,13 @@ type OAuth struct {
 type OAuthSpec struct {
 	// identityProviders is an ordered list of ways for a user to identify themselves.
 	// When this list is empty, no identities are provisioned for users.
+	//
+	// name is also used as the name-part of the Group annotation
+	// oauth.openshift.io/idp.<name> during OpenID group sync, so it must be a valid
+	// Kubernetes annotation name (alphanumeric, '-', '_', '.', at most 59 characters).
+	// Existing names that predate this restriction are grandfathered until changed.
+	//
+	// +kubebuilder:validation:XValidation:rule="self.all(idp, (idp.name.matches('^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$') && size(idp.name) <= 59) || (oldSelf.hasValue() && oldSelf.value().exists(old, old.name == idp.name)))",message="identity provider name must consist of alphanumeric characters, '-', '_' or '.', start and end with an alphanumeric character, and be at most 59 characters because it is used as a Kubernetes annotation key during group sync",optionalOldSelf=true
 	// +optional
 	// +listType=atomic
 	IdentityProviders []IdentityProvider `json:"identityProviders,omitempty"`
@@ -139,6 +146,9 @@ type IdentityProvider struct {
 	// - It MUST be unique and not shared by any other identity provider used
 	// - It MUST be a valid path segment: name cannot equal "." or ".." or contain "/" or "%" or ":"
 	//   Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName
+	// - It MUST also be a valid Kubernetes annotation name-part (alphanumeric characters,
+	//   '-', '_' or '.', starting and ending with an alphanumeric character, at most 59 characters)
+	//   because oauth-server writes oauth.openshift.io/idp.<name> onto Group objects during group sync.
 	Name string `json:"name"`
 
 	// mappingMethod determines how identities from this provider are mapped to users

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
@@ -51,6 +51,11 @@ spec:
                 description: |-
                   identityProviders is an ordered list of ways for a user to identify themselves.
                   When this list is empty, no identities are provisioned for users.
+
+                  name is also used as the name-part of the Group annotation
+                  oauth.openshift.io/idp.<name> during OpenID group sync, so it must be a valid
+                  Kubernetes annotation name (alphanumeric, '-', '_', '.', at most 59 characters).
+                  Existing names that predate this restriction are grandfathered until changed.
                 items:
                   description: IdentityProvider provides identities for users authenticating
                     using credentials
@@ -418,6 +423,9 @@ spec:
                         - It MUST be unique and not shared by any other identity provider used
                         - It MUST be a valid path segment: name cannot equal "." or ".." or contain "/" or "%" or ":"
                           Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName
+                        - It MUST also be a valid Kubernetes annotation name-part (alphanumeric characters,
+                          '-', '_' or '.', starting and ending with an alphanumeric character, at most 59 characters)
+                          because oauth-server writes oauth.openshift.io/idp.<name> onto Group objects during group sync.
                       type: string
                     openID:
                       description: openID enables user authentication using OpenID
@@ -597,6 +605,15 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: identity provider name must consist of alphanumeric characters,
+                    '-', '_' or '.', start and end with an alphanumeric character,
+                    and be at most 59 characters because it is used as a Kubernetes
+                    annotation key during group sync
+                  optionalOldSelf: true
+                  rule: self.all(idp, (idp.name.matches('^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$')
+                    && size(idp.name) <= 59) || (oldSelf.hasValue() && oldSelf.value().exists(old,
+                    old.name == idp.name)))
               templates:
                 description: templates allow you to customize pages like the login
                   page.

--- a/config/v1/zz_generated.featuregated-crd-manifests/oauths.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/oauths.config.openshift.io/AAA_ungated.yaml
@@ -52,6 +52,11 @@ spec:
                 description: |-
                   identityProviders is an ordered list of ways for a user to identify themselves.
                   When this list is empty, no identities are provisioned for users.
+
+                  name is also used as the name-part of the Group annotation
+                  oauth.openshift.io/idp.<name> during OpenID group sync, so it must be a valid
+                  Kubernetes annotation name (alphanumeric, '-', '_', '.', at most 59 characters).
+                  Existing names that predate this restriction are grandfathered until changed.
                 items:
                   description: IdentityProvider provides identities for users authenticating
                     using credentials
@@ -419,6 +424,9 @@ spec:
                         - It MUST be unique and not shared by any other identity provider used
                         - It MUST be a valid path segment: name cannot equal "." or ".." or contain "/" or "%" or ":"
                           Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName
+                        - It MUST also be a valid Kubernetes annotation name-part (alphanumeric characters,
+                          '-', '_' or '.', starting and ending with an alphanumeric character, at most 59 characters)
+                          because oauth-server writes oauth.openshift.io/idp.<name> onto Group objects during group sync.
                       type: string
                     openID:
                       description: openID enables user authentication using OpenID
@@ -598,6 +606,15 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: identity provider name must consist of alphanumeric characters,
+                    '-', '_' or '.', start and end with an alphanumeric character,
+                    and be at most 59 characters because it is used as a Kubernetes
+                    annotation key during group sync
+                  optionalOldSelf: true
+                  rule: self.all(idp, (idp.name.matches('^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$')
+                    && size(idp.name) <= 59) || (oldSelf.hasValue() && oldSelf.value().exists(old,
+                    old.name == idp.name)))
               templates:
                 description: templates allow you to customize pages like the login
                   page.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -2778,7 +2778,7 @@ func (HTPasswdIdentityProvider) SwaggerDoc() map[string]string {
 
 var map_IdentityProvider = map[string]string{
 	"":              "IdentityProvider provides identities for users authenticating using credentials",
-	"name":          "name is used to qualify the identities returned by this provider. - It MUST be unique and not shared by any other identity provider used - It MUST be a valid path segment: name cannot equal \".\" or \"..\" or contain \"/\" or \"%\" or \":\"\n  Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName",
+	"name":          "name is used to qualify the identities returned by this provider. - It MUST be unique and not shared by any other identity provider used - It MUST be a valid path segment: name cannot equal \".\" or \"..\" or contain \"/\" or \"%\" or \":\"\n  Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName\n- It MUST also be a valid Kubernetes annotation name-part (alphanumeric characters,\n  '-', '_' or '.', starting and ending with an alphanumeric character, at most 59 characters)\n  because oauth-server writes oauth.openshift.io/idp.<name> onto Group objects during group sync.",
 	"mappingMethod": "mappingMethod determines how identities from this provider are mapped to users Defaults to \"claim\"",
 }
 
@@ -2873,7 +2873,7 @@ func (OAuthRemoteConnectionInfo) SwaggerDoc() map[string]string {
 
 var map_OAuthSpec = map[string]string{
 	"":                  "OAuthSpec contains desired cluster auth configuration",
-	"identityProviders": "identityProviders is an ordered list of ways for a user to identify themselves. When this list is empty, no identities are provisioned for users.",
+	"identityProviders": "identityProviders is an ordered list of ways for a user to identify themselves. When this list is empty, no identities are provisioned for users.\n\nname is also used as the name-part of the Group annotation oauth.openshift.io/idp.<name> during OpenID group sync, so it must be a valid Kubernetes annotation name (alphanumeric, '-', '_', '.', at most 59 characters). Existing names that predate this restriction are grandfathered until changed.",
 	"tokenConfig":       "tokenConfig contains options for authorization and access tokens",
 	"templates":         "templates allow you to customize pages like the login page.",
 }

--- a/payload-manifests/crds/0000_10_config-operator_01_oauths.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_oauths.crd.yaml
@@ -51,6 +51,11 @@ spec:
                 description: |-
                   identityProviders is an ordered list of ways for a user to identify themselves.
                   When this list is empty, no identities are provisioned for users.
+
+                  name is also used as the name-part of the Group annotation
+                  oauth.openshift.io/idp.<name> during OpenID group sync, so it must be a valid
+                  Kubernetes annotation name (alphanumeric, '-', '_', '.', at most 59 characters).
+                  Existing names that predate this restriction are grandfathered until changed.
                 items:
                   description: IdentityProvider provides identities for users authenticating
                     using credentials
@@ -418,6 +423,9 @@ spec:
                         - It MUST be unique and not shared by any other identity provider used
                         - It MUST be a valid path segment: name cannot equal "." or ".." or contain "/" or "%" or ":"
                           Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName
+                        - It MUST also be a valid Kubernetes annotation name-part (alphanumeric characters,
+                          '-', '_' or '.', starting and ending with an alphanumeric character, at most 59 characters)
+                          because oauth-server writes oauth.openshift.io/idp.<name> onto Group objects during group sync.
                       type: string
                     openID:
                       description: openID enables user authentication using OpenID
@@ -597,6 +605,15 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: identity provider name must consist of alphanumeric characters,
+                    '-', '_' or '.', start and end with an alphanumeric character,
+                    and be at most 59 characters because it is used as a Kubernetes
+                    annotation key during group sync
+                  optionalOldSelf: true
+                  rule: self.all(idp, (idp.name.matches('^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$')
+                    && size(idp.name) <= 59) || (oldSelf.hasValue() && oldSelf.value().exists(old,
+                    old.name == idp.name)))
               templates:
                 description: templates allow you to customize pages like the login
                   page.


### PR DESCRIPTION
## Summary
- Close the oauth-server sanitization approach ([openshift/oauth-server#252](https://github.com/openshift/oauth-server/pull/252) is closed). Identity provider names that cannot be used as Kubernetes annotation keys are now rejected on the OAuth CRD instead.
- Add CEL on `spec.identityProviders` so `name` matches the annotation name-part used by oauth-server (`oauth.openshift.io/idp.<name>`): alphanumeric, `-`, `_`, `.`, start and end alphanumeric, at most 59 characters. This is the OCPBUGS-56908 failure (`Microsoft Entra ID`, `AIF - Keycloak`).
- Ratchet with `optionalOldSelf` so existing clusters that already have those names can still update the OAuth object until the name is changed. New names with spaces are rejected at admission.

## Test plan
- [x] CRD integration tests in `config/v1/tests/oauths.config.openshift.io/AAA_ungated.yaml` cover valid names, names with spaces, adding a new invalid IdP, and renaming to a valid name
- [ ] CI `verify` / integration tests for `oauths.config.openshift.io`
- [ ] Review with @liouk and @everettraven (agreed approach on OCPBUGS-56908)


Made with [Cursor](https://cursor.com)